### PR TITLE
Upgrade dropwizard-websocket to non-beta release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
       <dependency>
         <groupId>be.tomcools</groupId>
         <artifactId>dropwizard-websocket-jsr356-bundle</artifactId>
-        <version>4.0.0-beta.1</version>
+        <version>4.0.0</version>
       </dependency>
 
       <!-- jackson additions to DW BOM -->


### PR DESCRIPTION
I released a non-beta release of the bundle yesterday. 
I saw this project in my "used by" list on Github, so thought I might as well propose the change for you. 