### PR TITLE
Fixes for ID matching 

### DIFF
--- a/matching-ws/src/main/java/life/catalogue/matching/controller/IDController.java
+++ b/matching-ws/src/main/java/life/catalogue/matching/controller/IDController.java
@@ -36,9 +36,9 @@ public class IDController {
         "verification that an external ID for a specific dataset  (e.g. WoRMS)  has been indexed and to check if " +
         "the ID has been associated with a taxon in the main index. ")
   @ApiResponse(responseCode = "200", description = "Name usage suggestions found")
-  @Tag(name = "ID lookup services")
+  @Tag(name = "ID lookup services", description = "Services for checking which identifiers have been indexes and which are joined to the main index")
   @GetMapping(
-    value = {"v2/id/{datasetId}/{identifier}"},
+    value = {"v2/species/match/id/{datasetId}/{identifier}"},
     produces = "application/json")
   public List<ExternalID> matchV2(
     @PathVariable(value = "datasetId", required = false) String datasetId,
@@ -47,7 +47,7 @@ public class IDController {
     watch.start();
     List<ExternalID> ids = matchingService.matchID(datasetId, identifier);
     watch.stop();
-    log.info("v2/id/datasetId: {} {}, time: {}ms", datasetId, identifier, watch.getTime(TimeUnit.MILLISECONDS));
+    log.info("v2/species/match/id/datasetId: {} {}, time: {}ms", datasetId, identifier, watch.getTime(TimeUnit.MILLISECONDS));
     return ids;
   }
 
@@ -61,7 +61,7 @@ public class IDController {
   @ApiResponse(responseCode = "200", description = "Name usage suggestions found")
   @Tag(name = "ID lookup services")
   @GetMapping(
-    value = {"v2/id/{identifier}"},
+    value = {"v2/species/match/id/{identifier}"},
     produces = "application/json")
   public List<ExternalID> matchV2(
     @PathVariable(value = "identifier", required = false) String identifier) {
@@ -78,12 +78,11 @@ public class IDController {
     summary = "ID join lookup service",
     description =
       "A lookup service, largely intended for debug purposes, to enable " +
-        "verification that an external ID has been indexed and to check if " +
-        "the ID has been associated with a taxon in the main index. ")
+        "view which external IDS are joined to a name usage in the main index.")
   @ApiResponse(responseCode = "200", description = "Name usage suggestions found")
   @Tag(name = "ID lookup services")
   @GetMapping(
-    value = {"v2/joins/{identifier}"},
+    value = {"v2/species/match/joins/{identifier}"},
     produces = "application/json")
   public List<ExternalID> joins(
     @PathVariable(value = "identifier", required = false) String identifier) {

--- a/matching-ws/src/main/java/life/catalogue/matching/model/Dataset.java
+++ b/matching-ws/src/main/java/life/catalogue/matching/model/Dataset.java
@@ -22,4 +22,5 @@ public class Dataset {
   List<String> prefixMapping = List.of();
   Long taxonCount = 0L;
   Long matchesToMainIndex = 0L;
+  Boolean removePrefixForMatching = false;
 }

--- a/matching-ws/src/main/java/life/catalogue/matching/model/ExternalID.java
+++ b/matching-ws/src/main/java/life/catalogue/matching/model/ExternalID.java
@@ -19,8 +19,12 @@ public class ExternalID {
     private String id;
     @Schema(description = "The main index identifier that the external identifier was matched to")
     private String mainIndexID;
-    @Schema(description = "The dataset key of the main index identifier")
+    @Schema(description = "The gbif key of the dataset containing the joined external ID")
+    private String gbifKey;
+    @Schema(description = "The dataset key of the joined external ID")
     private String datasetKey;
+    @Schema(description = "The dataset title of the joined external ID")
+    private String datasetTitle;
     @Schema(description = "The parent ID of the external identifier")
     private String parentID;
     @Schema(description = "The scientific name associated with the external identifier")

--- a/matching-ws/src/main/java/life/catalogue/matching/model/NameUsageMatchFlatV1.java
+++ b/matching-ws/src/main/java/life/catalogue/matching/model/NameUsageMatchFlatV1.java
@@ -2,12 +2,11 @@ package life.catalogue.matching.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import life.catalogue.api.vocab.MatchType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.gbif.nameparser.api.Rank;
 
@@ -18,6 +17,7 @@ import org.gbif.nameparser.api.Rank;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Data
+@Schema(description = "A version 1 name usage match returned by the webservices. Includes higher taxonomy and diagnostics", title = "NameUsageMatchV1Flat", type = "object")
 public class NameUsageMatchFlatV1 implements Serializable {
 
   private static final long serialVersionUID = -8927655067465421358L;

--- a/matching-ws/src/main/java/life/catalogue/matching/model/NameUsageMatchV1.java
+++ b/matching-ws/src/main/java/life/catalogue/matching/model/NameUsageMatchV1.java
@@ -23,7 +23,7 @@ import lombok.Data;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @Data
 @Builder
-@Schema(description = "A name usage match returned by the webservices. Includes higher taxonomy and diagnostics", title = "NameUsageMatch", type = "object")
+@Schema(description = "A version 1 name usage match returned by the webservices. Includes higher taxonomy and diagnostics", title = "NameUsageMatchV1", type = "object")
 public class NameUsageMatchV1 {
 
   @Schema(description = "If the matched usage is a synonym")

--- a/matching-ws/src/main/java/life/catalogue/matching/model/NameUsageQuery.java
+++ b/matching-ws/src/main/java/life/catalogue/matching/model/NameUsageQuery.java
@@ -1,0 +1,64 @@
+package life.catalogue.matching.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.gbif.nameparser.api.Rank;
+import java.util.Set;
+import java.util.stream.Collectors;
+import static life.catalogue.matching.util.CleanupUtils.*;
+import static life.catalogue.matching.util.CleanupUtils.bool;
+
+@AllArgsConstructor
+@Builder
+public class NameUsageQuery {
+  final public String usageKey;
+  final public String taxonID;
+  final public String taxonConceptID;
+  final public String scientificNameID;
+  final public String scientificName;
+  final public String authorship;
+  final public String genericName;
+  final public String specificEpithet;
+  final public String infraSpecificEpithet;
+  final public Rank rank;
+  final public LinneanClassification classification;
+  final public Set<String> exclude;
+  final public Boolean strict;
+  final public Boolean verbose;
+
+  public static NameUsageQuery create(
+    String usageKey,
+    String taxonID,
+    String taxonConceptID,
+    String scientificNameID,
+    String scientificName2,
+    String scientificName,
+    String authorship2,
+    String authorship,
+    String rank2,
+    String rank,
+    String genericName,
+    String specificEpithet,
+    String infraspecificEpithet,
+    Classification classification,
+    Set<String> exclude,
+    Boolean strict,
+    Boolean verbose
+  ){
+    return new NameUsageQuery(
+      removeNulls(usageKey),
+      removeNulls(taxonID),
+      removeNulls(taxonConceptID),
+      removeNulls(scientificNameID),
+      first(removeNulls(scientificName), removeNulls(scientificName2)),
+      first(removeNulls(authorship), removeNulls(authorship2)),
+      removeNulls(genericName),
+      removeNulls(specificEpithet),
+      removeNulls(infraspecificEpithet),
+      parseRank(first(removeNulls(rank), removeNulls(rank2))),
+      clean(classification),
+      exclude != null ? exclude.stream().map(Object::toString).collect(Collectors.toSet()) : Set.of(),
+      bool(strict),
+      bool(verbose));
+  }
+}

--- a/matching-ws/src/main/resources/datasets.json
+++ b/matching-ws/src/main/resources/datasets.json
@@ -16,7 +16,8 @@
     "prefix": "urn:lsid:ipni.org:names:",
     "prefixMapping": [
       "https://www.ipni.org/n/"
-    ]
+    ],
+    "removePrefixForMatching": true
   },
   {
     "key": "2011",

--- a/matching-ws/src/test/java/life/catalogue/matching/DatasetIndexTest.java
+++ b/matching-ws/src/test/java/life/catalogue/matching/DatasetIndexTest.java
@@ -42,7 +42,7 @@ public class DatasetIndexTest {
 
   private static DatasetIndex index;
 
-  private static String dictionaryUrl = "/dictionaries/";
+  private static String dictionaryUrl = "dictionaries/";
 
   @BeforeAll
   public static void buildMatcher() throws Exception {

--- a/matching-ws/src/test/java/life/catalogue/matching/IDMatchingIT.java
+++ b/matching-ws/src/test/java/life/catalogue/matching/IDMatchingIT.java
@@ -71,11 +71,11 @@ public class IDMatchingIT {
   @Test
   public void testJoinHigherTaxa(){
 
-    NameUsageMatch match = matcher.match(
+    NameUsageMatch match = matcher.match(new NameUsageQuery(
       null, "ext-4", null, null, null, null,
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match);
     assertNotNull(match.getUsage());
@@ -86,21 +86,21 @@ public class IDMatchingIT {
   @Test
   public void testJoinLeafTaxa(){
 
-    NameUsageMatch match1 = matcher.match(
+    NameUsageMatch match1 = matcher.match(new NameUsageQuery(
       null, "ext-6", null, null, null, null,
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match1);
     assertNotNull(match1.getUsage());
     assertEquals("1011638", match1.getUsage().getKey());
 
-    NameUsageMatch match2 = matcher.match(
+    NameUsageMatch match2 = matcher.match(new NameUsageQuery(
       null, null, null, null, "Abacion tesselatum", null,
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match2);
     assertNotNull(match2.getUsage());
@@ -110,21 +110,21 @@ public class IDMatchingIT {
   @Test
   public void testJoinLeafTaxaWithPrefix(){
 
-    NameUsageMatch match1 = matcher.match(
+    NameUsageMatch match1 = matcher.match(new NameUsageQuery(
       null, "other-ext-", null, null, "Abacion tesselatum", null,
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match1);
     assertNotNull(match1.getUsage());
     assertEquals("1011638", match1.getUsage().getKey());
 
-    NameUsageMatch match2 = matcher.match(
+    NameUsageMatch match2 = matcher.match(new NameUsageQuery(
       null, "other-ext2-", null, null, "Abacion tesselatum", null,
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match2);
     assertNotNull(match2.getUsage());
@@ -134,11 +134,11 @@ public class IDMatchingIT {
   @Test
   public void testIDandNameInconsistent(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, "ext-6", null, null, "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertNotNull(match3.getUsage());
@@ -149,11 +149,11 @@ public class IDMatchingIT {
   @Test
   public void testTaxonIDNotFound(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, "ext-123", null, null, "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertTrue(match3.getDiagnostics().getIssues().contains(Issue.TAXON_ID_NOT_FOUND));
@@ -162,11 +162,11 @@ public class IDMatchingIT {
   @Test
   public void testTaxonConceptIDNotFound(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, null, "ext-123", null, "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertTrue(match3.getDiagnostics().getIssues().contains(Issue.TAXON_CONCEPT_ID_NOT_FOUND));
@@ -175,11 +175,11 @@ public class IDMatchingIT {
   @Test
   public void testScientificNameIDNotFound(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, null, null, "ext-123", "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertTrue(match3.getDiagnostics().getIssues().contains(Issue.SCIENTIFIC_NAME_ID_NOT_FOUND));
@@ -189,11 +189,11 @@ public class IDMatchingIT {
   @Test
   public void testTaxonIDIgnored(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, "ext-7", null, null, "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertTrue(match3.getDiagnostics().getIssues().contains(Issue.TAXON_ID_NOT_FOUND));
@@ -202,11 +202,11 @@ public class IDMatchingIT {
   @Test
   public void testTaxonConceptIDIgnored(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, null, "ext-7", null, "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertTrue(match3.getDiagnostics().getIssues().contains(Issue.TAXON_CONCEPT_ID_NOT_FOUND));
@@ -215,11 +215,11 @@ public class IDMatchingIT {
   @Test
   public void testScientificNameIDIgnored(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, null, null, "ext-7", "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertTrue(match3.getDiagnostics().getIssues().contains(Issue.SCIENTIFIC_NAME_ID_NOT_FOUND));
@@ -228,11 +228,11 @@ public class IDMatchingIT {
   @Test
   public void testTaxonNameAndIDAmbiguous(){
 
-    NameUsageMatch match3 = matcher.match(
+    NameUsageMatch match3 = matcher.match(new NameUsageQuery(
       null, null, null, "ext-6", "Abacion nonsense", "Abacionidae",
       null,null,null, null, null, null,
       false, false
-    );
+    ));
 
     assertNotNull(match3);
     assertTrue(match3.getDiagnostics().getIssues().contains(Issue.TAXON_MATCH_NAME_AND_ID_AMBIGUOUS));

--- a/matching-ws/src/test/java/life/catalogue/matching/MatchingServiceIT.java
+++ b/matching-ws/src/test/java/life/catalogue/matching/MatchingServiceIT.java
@@ -28,6 +28,7 @@ import life.catalogue.api.vocab.MatchType;
 import life.catalogue.matching.model.Classification;
 import life.catalogue.matching.model.LinneanClassification;
 import life.catalogue.matching.model.NameUsageMatch;
+import life.catalogue.matching.model.NameUsageQuery;
 import life.catalogue.matching.service.MatchingService;
 import life.catalogue.matching.util.Dictionaries;
 import life.catalogue.matching.util.NameParsers;
@@ -184,7 +185,7 @@ public class MatchingServiceIT {
       IntRange confidence,
       Set<String> exclude) {
     NameUsageMatch best =
-        matcher.match(usageKey, null, null, null, name, null, null, null, null, rank, query, exclude, false, true);
+        matcher.match(new NameUsageQuery(usageKey, null, null, null, name, null, null, null, null, rank, query, exclude, false, true));
 
     print(name, best);
 


### PR DESCRIPTION
Fixes for ID matching - stripping of prefix when prefix isn't included (ipni)
Improved logging for ID requests
Checks for exports and for existing indexes to reduce rebuild times 
regeneration of metadata on startup and when reindexing complete 
Comma separate identifier dataset ids