### PR TITLE
map has kleptoparasite to http://purl.obolibrary.org/obo/RO_0008504 i…

### DIFF
--- a/vocab/src/main/java/life/catalogue/api/vocab/SpeciesInteractionType.java
+++ b/vocab/src/main/java/life/catalogue/api/vocab/SpeciesInteractionType.java
@@ -160,7 +160,7 @@ public enum SpeciesInteractionType {
   KLEPTOPARASITE_OF("http://purl.obolibrary.org/obo/RO_0008503",
     "A sub-relation of parasite of in which a parasite steals resources from another organism, usually food or nest material",
     PARASITE_OF),
-  HAS_KLEPTOPARASITE("http://purl.obolibrary.org/obo/RO_0008503",
+  HAS_KLEPTOPARASITE("http://purl.obolibrary.org/obo/RO_0008504",
     "Inverse of kleptoparasite of",
     HAS_PARASITE),
 


### PR DESCRIPTION
…nstead of http://purl.obolibrary.org/obo/RO_0008503 (kleptoparasite of); related to https://github.com/globalbioticinteractions/globalbioticinteractions/issues/1156

fyi @mdoering - I stumbled across this suspicious interaction type mapping  and have prepared a potential patch. 