### PR TITLE
OpenRefine reconciliation services for parsers

### DIFF
--- a/parser/src/main/java/life/catalogue/parser/Parsers.java
+++ b/parser/src/main/java/life/catalogue/parser/Parsers.java
@@ -1,0 +1,50 @@
+package life.catalogue.parser;
+
+import java.util.*;
+
+/**
+ * Shared registry of the value parsers exposed by the API, keyed by a lower-case type name.
+ * Used by ParserResource and the parser reconciliation resources so the exposed set stays in sync.
+ * Holds only the vocabulary/scalar value parsers; the name parser lives in its own resource.
+ */
+public class Parsers {
+  public static final Map<String, Parser<?>> VOCAB;
+  static {
+    Map<String, Parser<?>> m = new HashMap<>();
+    m.put("boolean", BooleanParser.PARSER);
+    m.put("country", CountryParser.PARSER);
+    m.put("datasettype", DatasetTypeParser.PARSER);
+    m.put("date", DateParser.PARSER);
+    m.put("distributionstatus", DistributionStatusParser.PARSER);
+    m.put("gazetteer", GazetteerParser.PARSER);
+    m.put("geotime", GeoTimeParser.PARSER);
+    m.put("integer", IntegerParser.PARSER);
+    m.put("language", LanguageParser.PARSER);
+    m.put("license", LicenseParser.PARSER);
+    m.put("lifezone", EnvironmentParser.PARSER);
+    m.put("mediatype", MediaTypeParser.PARSER);
+    m.put("nomcode", NomCodeParser.PARSER);
+    m.put("nomreltype", NomRelTypeParser.PARSER);
+    m.put("nomstatus", NomStatusParser.PARSER);
+    m.put("rank", RankParser.PARSER);
+    m.put("referencetype", ReferenceTypeParser.PARSER);
+    m.put("sex", SexParser.PARSER);
+    m.put("taxonomicstatus", TaxonomicStatusParser.PARSER);
+    m.put("treatmentformat", TreatmentFormatParser.PARSER);
+    m.put("typestatus", TypeStatusParser.PARSER);
+    m.put("uri", UriParser.PARSER);
+    VOCAB = Collections.unmodifiableMap(m);
+  }
+
+  private Parsers() {}
+
+  public static Parser<?> get(String type) {
+    return type == null ? null : VOCAB.get(type.toLowerCase());
+  }
+
+  public static List<String> names() {
+    List<String> names = new ArrayList<>(VOCAB.keySet());
+    Collections.sort(names);
+    return names;
+  }
+}

--- a/parser/src/main/java/life/catalogue/parser/Parsers.java
+++ b/parser/src/main/java/life/catalogue/parser/Parsers.java
@@ -9,6 +9,7 @@ import java.util.*;
  */
 public class Parsers {
   public static final Map<String, Parser<?>> VOCAB;
+  private static final java.util.List<String> NAMES;
   static {
     Map<String, Parser<?>> m = new HashMap<>();
     m.put("area", AreaParser.PARSER);
@@ -35,17 +36,18 @@ public class Parsers {
     m.put("typestatus", TypeStatusParser.PARSER);
     m.put("uri", UriParser.PARSER);
     VOCAB = Collections.unmodifiableMap(m);
+    List<String> n = new ArrayList<>(VOCAB.keySet());
+    Collections.sort(n);
+    NAMES = Collections.unmodifiableList(n);
   }
 
   private Parsers() {}
 
   public static Parser<?> get(String type) {
-    return type == null ? null : VOCAB.get(type.toLowerCase());
+    return type == null ? null : VOCAB.get(type.toLowerCase(java.util.Locale.ROOT));
   }
 
   public static List<String> names() {
-    List<String> names = new ArrayList<>(VOCAB.keySet());
-    Collections.sort(names);
-    return names;
+    return NAMES;
   }
 }

--- a/parser/src/main/java/life/catalogue/parser/Parsers.java
+++ b/parser/src/main/java/life/catalogue/parser/Parsers.java
@@ -11,6 +11,7 @@ public class Parsers {
   public static final Map<String, Parser<?>> VOCAB;
   static {
     Map<String, Parser<?>> m = new HashMap<>();
+    m.put("area", AreaParser.PARSER);
     m.put("boolean", BooleanParser.PARSER);
     m.put("country", CountryParser.PARSER);
     m.put("datasettype", DatasetTypeParser.PARSER);

--- a/parser/src/test/java/life/catalogue/parser/ParsersTest.java
+++ b/parser/src/test/java/life/catalogue/parser/ParsersTest.java
@@ -9,6 +9,7 @@ public class ParsersTest {
   public void registryHasEnumVocabs() {
     assertNotNull(Parsers.get("rank"));
     assertNotNull(Parsers.get("country"));
+    assertNotNull(Parsers.get("area"));
     assertSame(Parsers.get("rank"), RankParser.PARSER);
     assertTrue(Parsers.names().contains("rank"));
     // scalars and dedicated parsers are NOT part of the shared vocab registry

--- a/parser/src/test/java/life/catalogue/parser/ParsersTest.java
+++ b/parser/src/test/java/life/catalogue/parser/ParsersTest.java
@@ -12,6 +12,7 @@ public class ParsersTest {
     assertNotNull(Parsers.get("area"));
     assertSame(Parsers.get("rank"), RankParser.PARSER);
     assertTrue(Parsers.names().contains("rank"));
+    assertTrue(Parsers.names().contains("area"));
     // scalars and dedicated parsers are NOT part of the shared vocab registry
     assertNull(Parsers.get("name"));
   }

--- a/parser/src/test/java/life/catalogue/parser/ParsersTest.java
+++ b/parser/src/test/java/life/catalogue/parser/ParsersTest.java
@@ -1,0 +1,17 @@
+package life.catalogue.parser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ParsersTest {
+  @Test
+  public void registryHasEnumVocabs() {
+    assertNotNull(Parsers.get("rank"));
+    assertNotNull(Parsers.get("country"));
+    assertSame(Parsers.get("rank"), RankParser.PARSER);
+    assertTrue(Parsers.names().contains("rank"));
+    // scalars and dedicated parsers are NOT part of the shared vocab registry
+    assertNull(Parsers.get("name"));
+  }
+}

--- a/webservice/src/main/java/life/catalogue/WsMatchingServer.java
+++ b/webservice/src/main/java/life/catalogue/WsMatchingServer.java
@@ -128,6 +128,7 @@ public class WsMatchingServer extends Application<WsMatchingServerConfig> {
       cfg.matchingDatasetKey, List.of(), dataset.getSize()+1, dataset.getSize()+1, cfg.matching, nidx
     );
     j.register(new NameParserResource());
+    j.register(new life.catalogue.resources.parser.openrefine.NameReconciliationResource(cfg.apiURI, cfg.clbURI));
     j.register(new FixedNameUsageMatchingResource(cfg.matching, dataset, matcher));
     j.register(new VersionResource(cfg.versionString(), LocalDateTime.now()));
 

--- a/webservice/src/main/java/life/catalogue/WsMatchingServerConfig.java
+++ b/webservice/src/main/java/life/catalogue/WsMatchingServerConfig.java
@@ -7,6 +7,7 @@ import life.catalogue.dw.cors.CorsBundleConfiguration;
 import life.catalogue.dw.cors.CorsConfiguration;
 import life.catalogue.matching.nidx.NamesIndexConfig;
 
+import java.net.URI;
 import java.util.Properties;
 
 import javax.annotation.Nullable;
@@ -54,6 +55,11 @@ public class WsMatchingServerConfig extends Configuration implements CorsBundleC
   @Valid
   @NotNull
   public MatchingConfig matching = new MatchingConfig();
+
+  @NotNull
+  public URI clbURI = URI.create("https://www.checklistbank.org");
+
+  public URI apiURI;
 
   @Override
   @JsonIgnore

--- a/webservice/src/main/java/life/catalogue/WsROServer.java
+++ b/webservice/src/main/java/life/catalogue/WsROServer.java
@@ -340,6 +340,7 @@ public class WsROServer extends Application<WsServerConfig> {
     j.register(new MetadataParserResource());
     j.register(new ParserResource<>());
     j.register(new life.catalogue.resources.parser.openrefine.VocabReconciliationResource(cfg.getApiUri(), cfg.clbURI));
+    j.register(new life.catalogue.resources.parser.openrefine.NameReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new ReferenceParserResource(doiResolver));
     j.register(new TaxGroupResource());
     j.register(new IdEncoderResource());

--- a/webservice/src/main/java/life/catalogue/WsROServer.java
+++ b/webservice/src/main/java/life/catalogue/WsROServer.java
@@ -342,6 +342,7 @@ public class WsROServer extends Application<WsServerConfig> {
     j.register(new life.catalogue.resources.parser.openrefine.VocabReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new life.catalogue.resources.parser.openrefine.NameReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new life.catalogue.resources.parser.openrefine.GeoTimeReconciliationResource(cfg.getApiUri(), cfg.clbURI));
+    j.register(new life.catalogue.resources.parser.openrefine.TaxGroupReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new ReferenceParserResource(doiResolver));
     j.register(new TaxGroupResource());
     j.register(new IdEncoderResource());

--- a/webservice/src/main/java/life/catalogue/WsROServer.java
+++ b/webservice/src/main/java/life/catalogue/WsROServer.java
@@ -339,6 +339,7 @@ public class WsROServer extends Application<WsServerConfig> {
     j.register(new NameParserResource());
     j.register(new MetadataParserResource());
     j.register(new ParserResource<>());
+    j.register(new life.catalogue.resources.parser.openrefine.VocabReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new ReferenceParserResource(doiResolver));
     j.register(new TaxGroupResource());
     j.register(new IdEncoderResource());

--- a/webservice/src/main/java/life/catalogue/WsROServer.java
+++ b/webservice/src/main/java/life/catalogue/WsROServer.java
@@ -341,6 +341,7 @@ public class WsROServer extends Application<WsServerConfig> {
     j.register(new ParserResource<>());
     j.register(new life.catalogue.resources.parser.openrefine.VocabReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new life.catalogue.resources.parser.openrefine.NameReconciliationResource(cfg.getApiUri(), cfg.clbURI));
+    j.register(new life.catalogue.resources.parser.openrefine.GeoTimeReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new ReferenceParserResource(doiResolver));
     j.register(new TaxGroupResource());
     j.register(new IdEncoderResource());

--- a/webservice/src/main/java/life/catalogue/WsROServer.java
+++ b/webservice/src/main/java/life/catalogue/WsROServer.java
@@ -343,6 +343,7 @@ public class WsROServer extends Application<WsServerConfig> {
     j.register(new life.catalogue.resources.parser.openrefine.NameReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new life.catalogue.resources.parser.openrefine.GeoTimeReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new life.catalogue.resources.parser.openrefine.TaxGroupReconciliationResource(cfg.getApiUri(), cfg.clbURI));
+    j.register(new life.catalogue.resources.parser.openrefine.AreaReconciliationResource(cfg.getApiUri(), cfg.clbURI));
     j.register(new ReferenceParserResource(doiResolver));
     j.register(new TaxGroupResource());
     j.register(new IdEncoderResource());

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/AbstractReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/AbstractReconciliationResource.java
@@ -14,17 +14,9 @@ import life.catalogue.matching.MatchingUtils;
 import life.catalogue.matching.UsageMatch;
 import life.catalogue.matching.UsageMatcher;
 import life.catalogue.matching.UsageMatcherFactory;
-import life.catalogue.parser.NomCodeParser;
-import life.catalogue.parser.RankParser;
-import life.catalogue.parser.SafeParser;
-
-import org.gbif.nameparser.api.NomCode;
-import org.gbif.nameparser.api.Rank;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,57 +148,13 @@ public abstract class AbstractReconciliationResource {
   }
 
   private OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, UsageMatcher matcher, MatchingUtils utils) {
-    var sn = toSimpleName(q);
+    var sn = OpenRefineQueries.toSimpleName(q);
     if (sn == null || StringUtils.isBlank(sn.getName())) {
       return new OpenRefineModel.Result();
     }
     IssueContainer issues = new IssueContainer.Simple();
     UsageMatch match = AbstractMatchingJob.interpretAndMatch(sn, sn.getClassification(), issues, true, interpreter, utils, matcher);
     return OpenRefineMapper.toResult(match);
-  }
-
-  /** Builds a query name from the OpenRefine query string and its property hints. */
-  private SimpleNameClassified<SimpleNameCached> toSimpleName(OpenRefineModel.Query q) {
-    if (q == null || StringUtils.isBlank(q.query)) {
-      return null;
-    }
-    String authorship = null;
-    Rank rank = null;
-    NomCode code = null;
-    List<SimpleNameCached> classification = new ArrayList<>();
-    if (q.properties != null) {
-      for (var p : q.properties) {
-        String val = textValue(p.v);
-        if (p.pid == null || val == null) continue;
-        switch (p.pid) {
-          case "authorship":
-            authorship = val;
-            break;
-          case "code":
-            code = SafeParser.parse(NomCodeParser.PARSER, val).orNull();
-            break;
-          case "rank":
-            rank = SafeParser.parse(RankParser.PARSER, val).orNull();
-            break;
-          default:
-            Rank r = SafeParser.parse(RankParser.PARSER, p.pid).orNull();
-            if (r != null) {
-              classification.add(SimpleNameClassified.snc(null, r, null, null, val, null));
-            }
-        }
-      }
-    }
-    var sn = SimpleNameClassified.snc(null, rank, code, null, q.query, authorship);
-    if (!classification.isEmpty()) {
-      sn.setClassification(classification);
-    }
-    return sn;
-  }
-
-  private static String textValue(JsonNode v) {
-    if (v == null || v.isNull()) return null;
-    String s = v.isValueNode() ? v.asText() : v.toString();
-    return StringUtils.trimToNull(s);
   }
 
   // ---- Data extension ----

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineModel.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineModel.java
@@ -107,6 +107,7 @@ public class OpenRefineModel {
 
   public static class ExtendService {
     public PropertySettings propose_properties;
+    public List<PropertySetting> property_settings;
 
     public ExtendService() {}
 
@@ -127,6 +128,28 @@ public class OpenRefineModel {
     }
   }
 
+  /** A configurable setting OpenRefine renders in the data-extension dialog. */
+  public static class PropertySetting {
+    public String name;
+    public String label;
+    public String type;
+    @com.fasterxml.jackson.annotation.JsonProperty("default")
+    public Object default_;
+    public List<SettingChoice> choices;
+  }
+
+  public static class SettingChoice {
+    public String value;
+    public String name;
+
+    public SettingChoice() {}
+
+    public SettingChoice(String value, String name) {
+      this.value = value;
+      this.name = name;
+    }
+  }
+
   // ---- Data extension ----
 
   /** Incoming data extension request: {@code { "ids": [...], "properties": [ {"id": ...} ] }}. */
@@ -139,6 +162,7 @@ public class OpenRefineModel {
   public static class ExtendProperty {
     public String id;
     public String name;
+    public Map<String, JsonNode> settings;
 
     public ExtendProperty() {}
 

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineModel.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineModel.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -133,7 +134,7 @@ public class OpenRefineModel {
     public String name;
     public String label;
     public String type;
-    @com.fasterxml.jackson.annotation.JsonProperty("default")
+    @JsonProperty("default")
     public Object default_;
     public List<SettingChoice> choices;
   }

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineQueries.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineQueries.java
@@ -1,0 +1,59 @@
+package life.catalogue.resources.matching.openrefine;
+
+import life.catalogue.api.model.SimpleNameCached;
+import life.catalogue.api.model.SimpleNameClassified;
+import life.catalogue.parser.NomCodeParser;
+import life.catalogue.parser.RankParser;
+import life.catalogue.parser.SafeParser;
+
+import org.gbif.nameparser.api.NomCode;
+import org.gbif.nameparser.api.Rank;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** Builds a query SimpleName from an OpenRefine reconciliation query + its property hints. */
+public class OpenRefineQueries {
+  private OpenRefineQueries() {}
+
+  public static SimpleNameClassified<SimpleNameCached> toSimpleName(OpenRefineModel.Query q) {
+    if (q == null || StringUtils.isBlank(q.query)) {
+      return null;
+    }
+    String authorship = null;
+    Rank rank = null;
+    NomCode code = null;
+    List<SimpleNameCached> classification = new ArrayList<>();
+    if (q.properties != null) {
+      for (var p : q.properties) {
+        String val = textValue(p.v);
+        if (p.pid == null || val == null) continue;
+        switch (p.pid) {
+          case "authorship": authorship = val; break;
+          case "code": code = SafeParser.parse(NomCodeParser.PARSER, val).orNull(); break;
+          case "rank": rank = SafeParser.parse(RankParser.PARSER, val).orNull(); break;
+          default:
+            Rank r = SafeParser.parse(RankParser.PARSER, p.pid).orNull();
+            if (r != null) {
+              classification.add(SimpleNameClassified.snc(null, r, null, null, val, null));
+            }
+        }
+      }
+    }
+    var sn = SimpleNameClassified.snc(null, rank, code, null, q.query, authorship);
+    if (!classification.isEmpty()) {
+      sn.setClassification(classification);
+    }
+    return sn;
+  }
+
+  static String textValue(JsonNode v) {
+    if (v == null || v.isNull()) return null;
+    String s = v.isValueNode() ? v.asText() : v.toString();
+    return StringUtils.trimToNull(s);
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineQueries.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineQueries.java
@@ -51,7 +51,7 @@ public class OpenRefineQueries {
     return sn;
   }
 
-  static String textValue(JsonNode v) {
+  private static String textValue(JsonNode v) {
     if (v == null || v.isNull()) return null;
     String s = v.isValueNode() ? v.asText() : v.toString();
     return StringUtils.trimToNull(s);

--- a/webservice/src/main/java/life/catalogue/resources/parser/ParserResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/ParserResource.java
@@ -59,7 +59,7 @@ public class ParserResource<T> {
   public List<ParseResult<?>> parseGet(@PathParam("type") String type, @QueryParam("q") List<String> values) {
     return parse(type, values.stream());
   }
-  
+
   /**
    * Parsing values as a json array.
    */
@@ -117,5 +117,4 @@ public class ParserResource<T> {
         .map(n -> new ParseResult<>(n, SafeParser.parse(parser, n)))
         .collect(Collectors.toList());
   }
-  
 }

--- a/webservice/src/main/java/life/catalogue/resources/parser/ParserResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/ParserResource.java
@@ -8,9 +8,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -30,34 +28,9 @@ public class ParserResource<T> {
   @SuppressWarnings("unused")
   private static final Logger LOG = LoggerFactory.getLogger(ParserResource.class);
   private final List<String> parserNames = new ArrayList<>();
-  private final Map<String, Parser<?>> parsers = new HashMap<>();
 
   public ParserResource() {
-    parsers.put("boolean", BooleanParser.PARSER);
-    parsers.put("country", CountryParser.PARSER);
-    parsers.put("datasettype", DatasetTypeParser.PARSER);
-    parsers.put("date", DateParser.PARSER);
-    parsers.put("distributionstatus", DistributionStatusParser.PARSER);
-    parsers.put("gazetteer", GazetteerParser.PARSER);
-    parsers.put("geotime", GeoTimeParser.PARSER);
-    parsers.put("integer", IntegerParser.PARSER);
-    parsers.put("language", LanguageParser.PARSER);
-    parsers.put("license", LicenseParser.PARSER);
-    parsers.put("lifezone", EnvironmentParser.PARSER);
-    parsers.put("mediatype", MediaTypeParser.PARSER);
-    parsers.put("nomcode", NomCodeParser.PARSER);
-    parsers.put("nomreltype", NomRelTypeParser.PARSER);
-    parsers.put("nomstatus", NomStatusParser.PARSER);
-    parsers.put("rank", RankParser.PARSER);
-    parsers.put("referencetype", ReferenceTypeParser.PARSER);
-    parsers.put("sex", SexParser.PARSER);
-//    parsers.put("taxgroup", TaxGroupParser.PARSER);
-    parsers.put("taxonomicstatus", TaxonomicStatusParser.PARSER);
-    parsers.put("treatmentformat", TreatmentFormatParser.PARSER);
-    parsers.put("typestatus", TypeStatusParser.PARSER);
-    parsers.put("uri", UriParser.PARSER);
-
-    parserNames.addAll(parsers.keySet());
+    parserNames.addAll(Parsers.names());
     parserNames.add("name"); // lives in its own resource
   }
 
@@ -136,11 +109,10 @@ public class ParserResource<T> {
   }
 
   private List<ParseResult<?>> parse(String type, Stream<String> rows) {
-    if (!parsers.containsKey(type.toLowerCase())) {
+    final Parser<?> parser = Parsers.get(type);
+    if (parser == null) {
       throw new NotFoundException("No parser for "+type+" exists");
     }
-
-    final Parser<?> parser = parsers.get(type);
     return rows
         .map(n -> new ParseResult<>(n, SafeParser.parse(parser, n)))
         .collect(Collectors.toList());

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/AbstractParserReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/AbstractParserReconciliationResource.java
@@ -1,0 +1,148 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.api.jackson.ApiModule;
+import life.catalogue.resources.matching.openrefine.OpenRefineMapper;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+
+/**
+ * Shared OpenRefine reconciliation HTTP plumbing for the dedicated parser services
+ * (name, geotime, taxgroup, area). Subclasses bind a concrete {@code @Path} and implement the hooks.
+ * Mirrors {@link life.catalogue.resources.matching.openrefine.AbstractReconciliationResource}.
+ */
+@Produces(MediaType.APPLICATION_JSON)
+public abstract class AbstractParserReconciliationResource {
+  protected static final int SUGGEST_LIMIT = 25;
+  protected final URI apiURI;
+  protected final URI clbURI;
+
+  protected AbstractParserReconciliationResource(URI apiURI, URI clbURI) {
+    this.apiURI = apiURI;
+    this.clbURI = clbURI;
+  }
+
+  // ---- hooks ----
+  /** path segment after /parser/, e.g. "name" -> /parser/name/reconcile */
+  protected abstract String typePath();
+  protected abstract OpenRefineModel.Manifest manifest(String reconcileBaseUrl, String clbBase);
+  protected abstract OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, MultivaluedMap<String, String> params);
+  protected abstract List<OpenRefineModel.ExtendProperty> extendProperties();
+  protected abstract String proposeType();
+  /** value for one id and one property; null -> empty cell */
+  protected abstract String extendValue(String id, OpenRefineModel.ExtendProperty prop, MultivaluedMap<String, String> params);
+  /** default: no suggest service */
+  protected OpenRefineModel.SuggestResponse suggestEntity(String prefix) {
+    return new OpenRefineModel.SuggestResponse();
+  }
+
+  protected String apiBase() {
+    return apiURI == null ? "" : StringUtils.removeEnd(apiURI.toString(), "/");
+  }
+  protected String reconcileBaseUrl() {
+    return apiBase() + "/parser/" + typePath() + "/reconcile";
+  }
+  protected String clbBase() {
+    return clbURI == null ? "https://www.checklistbank.org" : StringUtils.removeEnd(clbURI.toString(), "/");
+  }
+
+  @GET
+  public Object root(@QueryParam("queries") String queries, @Context UriInfo uriInfo) {
+    if (queries == null) {
+      return manifest(reconcileBaseUrl(), clbBase());
+    }
+    return reconcile(queries, uriInfo.getQueryParameters());
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  public Map<String, OpenRefineModel.Result> reconcileForm(@FormParam("queries") String queries, @Context UriInfo uriInfo) {
+    return reconcile(queries, uriInfo.getQueryParameters());
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Map<String, OpenRefineModel.Result> reconcileJson(String body, @Context UriInfo uriInfo) {
+    String queries = body;
+    try {
+      JsonNode node = ApiModule.MAPPER.readTree(body);
+      if (node != null && node.has("queries")) {
+        queries = node.get("queries").toString();
+      }
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid JSON body: " + e.getMessage());
+    }
+    return reconcile(queries, uriInfo.getQueryParameters());
+  }
+
+  private Map<String, OpenRefineModel.Result> reconcile(String queriesJson, MultivaluedMap<String, String> params) {
+    Map<String, OpenRefineModel.Query> queries;
+    try {
+      queries = OpenRefineMapper.parseQueries(queriesJson, ApiModule.MAPPER);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid queries payload: " + e.getMessage());
+    }
+    Map<String, OpenRefineModel.Result> out = new LinkedHashMap<>();
+    for (var e : queries.entrySet()) {
+      var q = e.getValue();
+      out.put(e.getKey(), q == null || StringUtils.isBlank(q.query)
+        ? new OpenRefineModel.Result()
+        : reconcileSingle(q, params));
+    }
+    return out;
+  }
+
+  @POST
+  @Path("extend")
+  @Consumes(MediaType.APPLICATION_JSON)
+  public OpenRefineModel.ExtendResponse extend(OpenRefineModel.ExtendQuery query, @Context UriInfo uriInfo) {
+    var params = uriInfo.getQueryParameters();
+    List<String> ids = query == null || query.ids == null ? List.of() : query.ids;
+    List<OpenRefineModel.ExtendProperty> props = query == null || query.properties == null ? List.of() : query.properties;
+    var resp = new OpenRefineModel.ExtendResponse();
+    for (var p : props) {
+      resp.meta.add(new OpenRefineModel.ExtendProperty(p.id, propertyName(p.id)));
+    }
+    for (String id : ids) {
+      var row = new LinkedHashMap<String, List<OpenRefineModel.Cell>>();
+      for (var p : props) {
+        String value = extendValue(id, p, params);
+        row.put(p.id, value == null ? List.of() : List.of(new OpenRefineModel.Cell(value)));
+      }
+      resp.rows.put(id, row);
+    }
+    return resp;
+  }
+
+  @GET
+  @Path("extend/propose")
+  public OpenRefineModel.ProposeResponse propose() {
+    var resp = new OpenRefineModel.ProposeResponse(extendProperties());
+    resp.type = proposeType();
+    return resp;
+  }
+
+  @GET
+  @Path("suggest/entity")
+  public OpenRefineModel.SuggestResponse suggest(@QueryParam("prefix") String prefix) {
+    return suggestEntity(prefix);
+  }
+
+  private String propertyName(String pid) {
+    return extendProperties().stream().filter(p -> p.id.equals(pid)).map(p -> p.name).findFirst().orElse(pid);
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/AreaReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/AreaReconciliationResource.java
@@ -1,0 +1,51 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.api.vocab.area.Area;
+import life.catalogue.parser.AreaParser;
+import life.catalogue.parser.SafeParser;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import java.net.URI;
+import java.util.List;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+@Path("/parser/area/reconcile")
+public class AreaReconciliationResource extends AbstractParserReconciliationResource {
+
+  public AreaReconciliationResource(URI apiURI, URI clbURI) {
+    super(apiURI, clbURI);
+  }
+
+  @Override
+  protected String typePath() {
+    return "area";
+  }
+
+  @Override
+  protected OpenRefineModel.Manifest manifest(String reconcileBaseUrl, String clbBase) {
+    return ParserOpenRefineMapper.areaManifest(reconcileBaseUrl, clbBase);
+  }
+
+  @Override
+  protected OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, MultivaluedMap<String, String> params) {
+    return ParserOpenRefineMapper.areaResult(q.query);
+  }
+
+  @Override
+  protected List<OpenRefineModel.ExtendProperty> extendProperties() {
+    return ParserOpenRefineMapper.AREA_PROPERTIES;
+  }
+
+  @Override
+  protected String proposeType() {
+    return "Area";
+  }
+
+  @Override
+  protected String extendValue(String id, OpenRefineModel.ExtendProperty p, MultivaluedMap<String, String> params) {
+    Area a = SafeParser.parse(AreaParser.PARSER, id).orNull();
+    return ParserOpenRefineMapper.areaValue(a, p.id);
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/GeoTimeReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/GeoTimeReconciliationResource.java
@@ -1,0 +1,66 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.api.vocab.GeoTime;
+import life.catalogue.parser.GeoTimeParser;
+import life.catalogue.parser.SafeParser;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import java.net.URI;
+import java.util.List;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+@Path("/parser/geotime/reconcile")
+public class GeoTimeReconciliationResource extends AbstractParserReconciliationResource {
+
+  public GeoTimeReconciliationResource(URI apiURI, URI clbURI) {
+    super(apiURI, clbURI);
+  }
+
+  @Override
+  protected String typePath() {
+    return "geotime";
+  }
+
+  @Override
+  protected OpenRefineModel.Manifest manifest(String reconcileBaseUrl, String clbBase) {
+    return ParserOpenRefineMapper.geoTimeManifest(reconcileBaseUrl, clbBase);
+  }
+
+  @Override
+  protected OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, MultivaluedMap<String, String> params) {
+    var result = new OpenRefineModel.Result();
+    GeoTime gt = SafeParser.parse(GeoTimeParser.PARSER, q.query).orNull();
+    if (gt != null) {
+      var c = new OpenRefineModel.Candidate();
+      c.id = gt.getName();
+      c.name = gt.getName();
+      c.score = 100;
+      c.match = true;
+      c.type.add(ParserOpenRefineMapper.GEOTIME_TYPE);
+      result.result.add(c);
+    }
+    return result;
+  }
+
+  @Override
+  protected List<OpenRefineModel.ExtendProperty> extendProperties() {
+    return ParserOpenRefineMapper.GEOTIME_PROPERTIES;
+  }
+
+  @Override
+  protected String proposeType() {
+    return "GeoTime";
+  }
+
+  @Override
+  protected String extendValue(String id, OpenRefineModel.ExtendProperty p, MultivaluedMap<String, String> params) {
+    return ParserOpenRefineMapper.geoTimeValue(GeoTime.byName(id), p.id);
+  }
+
+  @Override
+  protected OpenRefineModel.SuggestResponse suggestEntity(String prefix) {
+    return ParserOpenRefineMapper.geoTimeSuggest(prefix, SUGGEST_LIMIT);
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/NameReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/NameReconciliationResource.java
@@ -4,6 +4,7 @@ import life.catalogue.api.model.IssueContainer;
 import life.catalogue.api.model.ParsedNameUsage;
 import life.catalogue.parser.NameParser;
 import life.catalogue.parser.NomCodeParser;
+import life.catalogue.parser.Parser;
 import life.catalogue.parser.RankParser;
 import life.catalogue.parser.SafeParser;
 import life.catalogue.resources.matching.openrefine.OpenRefineModel;
@@ -66,6 +67,7 @@ public class NameReconciliationResource extends AbstractParserReconciliationReso
   protected String extendValue(String id, OpenRefineModel.ExtendProperty p, MultivaluedMap<String, String> params) {
     NomCode code = settingOr(p, "code", NomCodeParser.PARSER, paramCode(params));
     Rank rank = settingOr(p, "rank", RankParser.PARSER, paramRank(params));
+    // re-parse per property: each property may carry its own code/rank in settings, so a single parse-per-id would not honour per-property context
     var pnu = parse(id, code, rank);
     return pnu == null ? null : ParserOpenRefineMapper.nameValue(pnu.getName(), pnu, p.id);
   }
@@ -87,7 +89,7 @@ public class NameReconciliationResource extends AbstractParserReconciliationReso
     return params == null ? null : SafeParser.parse(RankParser.PARSER, params.getFirst("rank")).orNull();
   }
 
-  private <T> T settingOr(OpenRefineModel.ExtendProperty p, String key, life.catalogue.parser.Parser<T> parser, T fallback) {
+  private <T> T settingOr(OpenRefineModel.ExtendProperty p, String key, Parser<T> parser, T fallback) {
     if (p.settings != null && p.settings.get(key) != null) {
       String raw = StringUtils.trimToNull(p.settings.get(key).asText());
       if (raw != null) {

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/NameReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/NameReconciliationResource.java
@@ -1,0 +1,100 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.api.model.IssueContainer;
+import life.catalogue.api.model.ParsedNameUsage;
+import life.catalogue.parser.NameParser;
+import life.catalogue.parser.NomCodeParser;
+import life.catalogue.parser.RankParser;
+import life.catalogue.parser.SafeParser;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import org.gbif.nameparser.api.NomCode;
+import org.gbif.nameparser.api.Rank;
+
+import java.net.URI;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+@Path("/parser/name/reconcile")
+public class NameReconciliationResource extends AbstractParserReconciliationResource {
+
+  public NameReconciliationResource(URI apiURI, URI clbURI) {
+    super(apiURI, clbURI);
+  }
+
+  @Override
+  protected String typePath() {
+    return "name";
+  }
+
+  @Override
+  protected OpenRefineModel.Manifest manifest(String reconcileBaseUrl, String clbBase) {
+    return ParserOpenRefineMapper.nameManifest(reconcileBaseUrl, clbBase);
+  }
+
+  @Override
+  protected OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, MultivaluedMap<String, String> params) {
+    var result = new OpenRefineModel.Result();
+    var pnu = parse(q.query, paramCode(params), paramRank(params));
+    if (pnu != null) {
+      var c = new OpenRefineModel.Candidate();
+      c.id = q.query; // raw input -> re-parseable at extend
+      c.name = pnu.getName().getLabel();
+      c.score = 100;
+      c.match = true;
+      c.type.add(ParserOpenRefineMapper.NAME_TYPE);
+      result.result.add(c);
+    }
+    return result;
+  }
+
+  @Override
+  protected List<OpenRefineModel.ExtendProperty> extendProperties() {
+    return ParserOpenRefineMapper.NAME_PROPERTIES;
+  }
+
+  @Override
+  protected String proposeType() {
+    return "Name";
+  }
+
+  @Override
+  protected String extendValue(String id, OpenRefineModel.ExtendProperty p, MultivaluedMap<String, String> params) {
+    NomCode code = settingOr(p, "code", NomCodeParser.PARSER, paramCode(params));
+    Rank rank = settingOr(p, "rank", RankParser.PARSER, paramRank(params));
+    var pnu = parse(id, code, rank);
+    return pnu == null ? null : ParserOpenRefineMapper.nameValue(pnu.getName(), pnu, p.id);
+  }
+
+  private ParsedNameUsage parse(String name, NomCode code, Rank rank) {
+    try {
+      return NameParser.PARSER.parse(name, null, rank, code, IssueContainer.VOID).orElse(null);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
+  }
+
+  private NomCode paramCode(MultivaluedMap<String, String> params) {
+    return params == null ? null : SafeParser.parse(NomCodeParser.PARSER, params.getFirst("code")).orNull();
+  }
+
+  private Rank paramRank(MultivaluedMap<String, String> params) {
+    return params == null ? null : SafeParser.parse(RankParser.PARSER, params.getFirst("rank")).orNull();
+  }
+
+  private <T> T settingOr(OpenRefineModel.ExtendProperty p, String key, life.catalogue.parser.Parser<T> parser, T fallback) {
+    if (p.settings != null && p.settings.get(key) != null) {
+      String raw = StringUtils.trimToNull(p.settings.get(key).asText());
+      if (raw != null) {
+        T v = SafeParser.parse(parser, raw).orNull();
+        if (v != null) return v;
+      }
+    }
+    return fallback;
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/NameReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/NameReconciliationResource.java
@@ -40,7 +40,7 @@ public class NameReconciliationResource extends AbstractParserReconciliationReso
   protected OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, MultivaluedMap<String, String> params) {
     var result = new OpenRefineModel.Result();
     var pnu = parse(q.query, paramCode(params), paramRank(params));
-    if (pnu != null) {
+    if (pnu != null && pnu.getName().getType() != null && pnu.getName().getType().isParsable()) {
       var c = new OpenRefineModel.Candidate();
       c.id = q.query; // raw input -> re-parseable at extend
       c.name = pnu.getName().getLabel();

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -1,5 +1,7 @@
 package life.catalogue.resources.parser.openrefine;
 
+import life.catalogue.api.model.Name;
+import life.catalogue.api.model.ParsedNameUsage;
 import life.catalogue.api.vocab.GeoTime;
 import life.catalogue.api.vocab.TaxGroup;
 import life.catalogue.api.vocab.area.Area;
@@ -8,6 +10,11 @@ import life.catalogue.parser.Parser;
 import life.catalogue.parser.SafeParser;
 import life.catalogue.resources.matching.openrefine.OpenRefineModel;
 
+import org.gbif.nameparser.api.Authorship;
+import org.gbif.nameparser.api.NomCode;
+import org.gbif.nameparser.api.Rank;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -111,9 +118,9 @@ public class ParserOpenRefineMapper {
   private static OpenRefineModel.PropertySetting codeSetting() {
     var s = new OpenRefineModel.PropertySetting();
     s.name = "code"; s.label = "Nomenclatural code"; s.type = "select"; s.default_ = "";
-    s.choices = new java.util.ArrayList<>();
+    s.choices = new ArrayList<>();
     s.choices.add(new OpenRefineModel.SettingChoice("", "auto-detect"));
-    for (org.gbif.nameparser.api.NomCode c : org.gbif.nameparser.api.NomCode.values()) {
+    for (NomCode c : NomCode.values()) {
       s.choices.add(new OpenRefineModel.SettingChoice(c.name(), c.getAcronym() == null ? c.name() : c.getAcronym()));
     }
     return s;
@@ -122,15 +129,15 @@ public class ParserOpenRefineMapper {
   private static OpenRefineModel.PropertySetting rankSetting() {
     var s = new OpenRefineModel.PropertySetting();
     s.name = "rank"; s.label = "Rank"; s.type = "select"; s.default_ = "";
-    s.choices = new java.util.ArrayList<>();
+    s.choices = new ArrayList<>();
     s.choices.add(new OpenRefineModel.SettingChoice("", "auto-detect"));
-    for (org.gbif.nameparser.api.Rank r : org.gbif.nameparser.api.Rank.values()) {
+    for (Rank r : Rank.values()) {
       s.choices.add(new OpenRefineModel.SettingChoice(r.name(), r.name().toLowerCase()));
     }
     return s;
   }
 
-  public static String nameValue(life.catalogue.api.model.Name n, life.catalogue.api.model.ParsedNameUsage pnu, String pid) {
+  public static String nameValue(Name n, ParsedNameUsage pnu, String pid) {
     if (n == null || pid == null) return null;
     switch (pid) {
       case "label": return n.getLabel();
@@ -158,11 +165,11 @@ public class ParserOpenRefineMapper {
     }
   }
 
-  private static String authorship(org.gbif.nameparser.api.Authorship a) {
+  private static String authorship(Authorship a) {
     return a == null || a.isEmpty() ? null : a.toString();
   }
 
-  private static String year(org.gbif.nameparser.api.Authorship a) {
+  private static String year(Authorship a) {
     return a == null ? null : a.getYear();
   }
 

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -1,0 +1,65 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.parser.Parser;
+import life.catalogue.parser.SafeParser;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** Pure mapping between the CoL parsers and the OpenRefine reconciliation protocol. */
+public class ParserOpenRefineMapper {
+  private ParserOpenRefineMapper() {}
+
+  public static OpenRefineModel.Type vocabType(String type) {
+    return new OpenRefineModel.Type(type, type);
+  }
+
+  /** One auto-matched candidate for a parsable value, else an empty result. */
+  public static OpenRefineModel.Result vocabResult(Parser<?> parser, String value) {
+    var result = new OpenRefineModel.Result();
+    Object parsed = SafeParser.parse(parser, value).orNull();
+    if (parsed != null) {
+      var c = new OpenRefineModel.Candidate();
+      c.id = parsed instanceof Enum ? ((Enum<?>) parsed).name() : parsed.toString();
+      c.name = parsed.toString();
+      c.score = 100;
+      c.match = true;
+      c.type.add(vocabType(typeName(parser)));
+      result.result.add(c);
+    }
+    return result;
+  }
+
+  private static String typeName(Parser<?> parser) {
+    return parser.getClass().getSimpleName().replaceAll("Parser$", "").toLowerCase();
+  }
+
+  public static OpenRefineModel.SuggestResponse enumSuggest(Class<? extends Enum> enumClass, String prefix, int limit) {
+    var resp = new OpenRefineModel.SuggestResponse();
+    String p = prefix == null ? "" : prefix.toLowerCase();
+    for (Enum<?> e : enumClass.getEnumConstants()) {
+      if (resp.result.size() >= limit) break;
+      if (p.isEmpty() || e.name().toLowerCase().startsWith(p) || e.toString().toLowerCase().startsWith(p)) {
+        var item = new OpenRefineModel.SuggestItem();
+        item.id = e.name();
+        item.name = e.toString();
+        resp.result.add(item);
+      }
+    }
+    return resp;
+  }
+
+  public static OpenRefineModel.Manifest vocabManifest(String type, String apiReconcileUrl, String clbBaseUrl, boolean enumBacked) {
+    var m = new OpenRefineModel.Manifest();
+    m.name = "Catalogue of Life — " + type + " parser";
+    String space = StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/" + type;
+    m.identifierSpace = space;
+    m.schemaSpace = space;
+    m.defaultTypes.add(vocabType(type));
+    if (enumBacked) {
+      m.suggest = new OpenRefineModel.SuggestServices();
+      m.suggest.entity = new OpenRefineModel.SuggestService(apiReconcileUrl, "/suggest/entity");
+    }
+    return m;
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -2,6 +2,8 @@ package life.catalogue.resources.parser.openrefine;
 
 import life.catalogue.api.vocab.GeoTime;
 import life.catalogue.api.vocab.TaxGroup;
+import life.catalogue.api.vocab.area.Area;
+import life.catalogue.parser.AreaParser;
 import life.catalogue.parser.Parser;
 import life.catalogue.parser.SafeParser;
 import life.catalogue.resources.matching.openrefine.OpenRefineModel;
@@ -241,6 +243,52 @@ public class ParserOpenRefineMapper {
         g.getCodes().stream().map(Enum::name).collect(java.util.stream.Collectors.joining(";"));
       case "description": return g.getDescription();
       case "icon": return g.getIconSVG() == null ? null : g.getIconSVG().toString();
+      default: return null;
+    }
+  }
+
+  public static final OpenRefineModel.Type AREA_TYPE = new OpenRefineModel.Type("Area", "Area");
+
+  public static final java.util.List<OpenRefineModel.ExtendProperty> AREA_PROPERTIES = java.util.List.of(
+    new OpenRefineModel.ExtendProperty("gazetteer", "gazetteer"),
+    new OpenRefineModel.ExtendProperty("id", "id"),
+    new OpenRefineModel.ExtendProperty("name", "name"),
+    new OpenRefineModel.ExtendProperty("globalId", "global id"),
+    new OpenRefineModel.ExtendProperty("link", "link")
+  );
+
+  public static OpenRefineModel.Manifest areaManifest(String apiReconcileUrl, String clbBaseUrl) {
+    var m = new OpenRefineModel.Manifest();
+    m.name = "Catalogue of Life — area";
+    String space = StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/gazetteer";
+    m.identifierSpace = space; m.schemaSpace = space;
+    m.defaultTypes.add(AREA_TYPE);
+    m.extend = new OpenRefineModel.ExtendService(new OpenRefineModel.PropertySettings(apiReconcileUrl, "/extend/propose"));
+    return m;
+  }
+
+  public static OpenRefineModel.Result areaResult(String value) {
+    var result = new OpenRefineModel.Result();
+    Area a = SafeParser.parse(AreaParser.PARSER, value).orNull();
+    if (a != null && a.getGlobalId() != null) {
+      var c = new OpenRefineModel.Candidate();
+      c.id = a.getGlobalId();
+      c.name = a.getName() != null ? a.getName() : a.getGlobalId();
+      c.score = 100; c.match = true;
+      c.type.add(AREA_TYPE);
+      result.result.add(c);
+    }
+    return result;
+  }
+
+  public static String areaValue(Area a, String pid) {
+    if (a == null || pid == null) return null;
+    switch (pid) {
+      case "gazetteer": return a.getGazetteer() == null ? null : a.getGazetteer().name();
+      case "id": return a.getId();
+      case "name": return a.getName();
+      case "globalId": return a.getGlobalId();
+      case "link": return a.getLink() == null ? null : a.getLink().toString();
       default: return null;
     }
   }

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -146,7 +146,7 @@ public class ParserOpenRefineMapper {
       case "nomenclaturalNote": return n.getNomenclaturalNote();
       case "taxonomicNote": return pnu == null ? null : pnu.getTaxonomicNote();
       case "extinct": return pnu == null ? null : String.valueOf(pnu.isExtinct());
-      case "parsed": return String.valueOf(n.getType() == null || n.getType().isParsable());
+      case "parsed": return String.valueOf(n.getType() != null && n.getType().isParsable());
       default: return null;
     }
   }

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -15,7 +15,7 @@ public class ParserOpenRefineMapper {
   }
 
   /** One auto-matched candidate for a parsable value, else an empty result. */
-  public static OpenRefineModel.Result vocabResult(Parser<?> parser, String value) {
+  public static OpenRefineModel.Result vocabResult(Parser<?> parser, String type, String value) {
     var result = new OpenRefineModel.Result();
     Object parsed = SafeParser.parse(parser, value).orNull();
     if (parsed != null) {
@@ -24,16 +24,14 @@ public class ParserOpenRefineMapper {
       c.name = parsed.toString();
       c.score = 100;
       c.match = true;
-      c.type.add(vocabType(typeName(parser)));
+      c.type.add(vocabType(type.toLowerCase()));
       result.result.add(c);
     }
     return result;
   }
 
-  private static String typeName(Parser<?> parser) {
-    return parser.getClass().getSimpleName().replaceAll("Parser$", "").toLowerCase();
-  }
-
+  // EnumParser uses a raw Enum bound, so we cannot tighten this to Enum<?> here
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public static OpenRefineModel.SuggestResponse enumSuggest(Class<? extends Enum> enumClass, String prefix, int limit) {
     var resp = new OpenRefineModel.SuggestResponse();
     String p = prefix == null ? "" : prefix.toLowerCase();

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -60,4 +60,102 @@ public class ParserOpenRefineMapper {
     }
     return m;
   }
+
+  public static final OpenRefineModel.Type NAME_TYPE = new OpenRefineModel.Type("Name", "Name");
+
+  public static final java.util.List<OpenRefineModel.ExtendProperty> NAME_PROPERTIES = java.util.List.of(
+    new OpenRefineModel.ExtendProperty("label", "label"),
+    new OpenRefineModel.ExtendProperty("labelHtml", "label (HTML)"),
+    new OpenRefineModel.ExtendProperty("scientificName", "scientific name"),
+    new OpenRefineModel.ExtendProperty("authorship", "authorship"),
+    new OpenRefineModel.ExtendProperty("rank", "rank"),
+    new OpenRefineModel.ExtendProperty("code", "nomenclatural code"),
+    new OpenRefineModel.ExtendProperty("type", "name type"),
+    new OpenRefineModel.ExtendProperty("uninomial", "uninomial"),
+    new OpenRefineModel.ExtendProperty("genus", "genus"),
+    new OpenRefineModel.ExtendProperty("infragenericEpithet", "infrageneric epithet"),
+    new OpenRefineModel.ExtendProperty("specificEpithet", "specific epithet"),
+    new OpenRefineModel.ExtendProperty("infraspecificEpithet", "infraspecific epithet"),
+    new OpenRefineModel.ExtendProperty("cultivarEpithet", "cultivar epithet"),
+    new OpenRefineModel.ExtendProperty("combinationAuthorship", "combination authorship"),
+    new OpenRefineModel.ExtendProperty("combinationYear", "combination year"),
+    new OpenRefineModel.ExtendProperty("basionymAuthorship", "basionym authorship"),
+    new OpenRefineModel.ExtendProperty("basionymYear", "basionym year"),
+    new OpenRefineModel.ExtendProperty("nomenclaturalNote", "nomenclatural note"),
+    new OpenRefineModel.ExtendProperty("taxonomicNote", "taxonomic note"),
+    new OpenRefineModel.ExtendProperty("extinct", "extinct"),
+    new OpenRefineModel.ExtendProperty("parsed", "parsed")
+  );
+
+  public static OpenRefineModel.Manifest nameManifest(String apiReconcileUrl, String clbBaseUrl) {
+    var m = new OpenRefineModel.Manifest();
+    m.name = "Catalogue of Life — name parser";
+    String space = org.apache.commons.lang3.StringUtils.removeEnd(clbBaseUrl, "/") + "/tools/name-parser";
+    m.identifierSpace = space;
+    m.schemaSpace = space;
+    m.defaultTypes.add(NAME_TYPE);
+    var extend = new OpenRefineModel.ExtendService(
+      new OpenRefineModel.PropertySettings(apiReconcileUrl, "/extend/propose"));
+    extend.property_settings = java.util.List.of(codeSetting(), rankSetting());
+    m.extend = extend;
+    return m;
+  }
+
+  private static OpenRefineModel.PropertySetting codeSetting() {
+    var s = new OpenRefineModel.PropertySetting();
+    s.name = "code"; s.label = "Nomenclatural code"; s.type = "select"; s.default_ = "";
+    s.choices = new java.util.ArrayList<>();
+    s.choices.add(new OpenRefineModel.SettingChoice("", "auto-detect"));
+    for (org.gbif.nameparser.api.NomCode c : org.gbif.nameparser.api.NomCode.values()) {
+      s.choices.add(new OpenRefineModel.SettingChoice(c.name(), c.getAcronym() == null ? c.name() : c.getAcronym()));
+    }
+    return s;
+  }
+
+  private static OpenRefineModel.PropertySetting rankSetting() {
+    var s = new OpenRefineModel.PropertySetting();
+    s.name = "rank"; s.label = "Rank"; s.type = "select"; s.default_ = "";
+    s.choices = new java.util.ArrayList<>();
+    s.choices.add(new OpenRefineModel.SettingChoice("", "auto-detect"));
+    for (org.gbif.nameparser.api.Rank r : org.gbif.nameparser.api.Rank.values()) {
+      s.choices.add(new OpenRefineModel.SettingChoice(r.name(), r.name().toLowerCase()));
+    }
+    return s;
+  }
+
+  public static String nameValue(life.catalogue.api.model.Name n, life.catalogue.api.model.ParsedNameUsage pnu, String pid) {
+    if (n == null || pid == null) return null;
+    switch (pid) {
+      case "label": return n.getLabel();
+      case "labelHtml": return n.getLabelHtml();
+      case "scientificName": return n.getScientificName();
+      case "authorship": return n.getAuthorship();
+      case "rank": return n.getRank() == null ? null : n.getRank().name().toLowerCase();
+      case "code": return n.getCode() == null ? null : n.getCode().name();
+      case "type": return n.getType() == null ? null : n.getType().name();
+      case "uninomial": return n.getUninomial();
+      case "genus": return n.getGenus();
+      case "infragenericEpithet": return n.getInfragenericEpithet();
+      case "specificEpithet": return n.getSpecificEpithet();
+      case "infraspecificEpithet": return n.getInfraspecificEpithet();
+      case "cultivarEpithet": return n.getCultivarEpithet();
+      case "combinationAuthorship": return authorship(n.getCombinationAuthorship());
+      case "combinationYear": return year(n.getCombinationAuthorship());
+      case "basionymAuthorship": return authorship(n.getBasionymAuthorship());
+      case "basionymYear": return year(n.getBasionymAuthorship());
+      case "nomenclaturalNote": return n.getNomenclaturalNote();
+      case "taxonomicNote": return pnu == null ? null : pnu.getTaxonomicNote();
+      case "extinct": return pnu == null ? null : String.valueOf(pnu.isExtinct());
+      case "parsed": return String.valueOf(n.getType() == null || n.getType().isParsable());
+      default: return null;
+    }
+  }
+
+  private static String authorship(org.gbif.nameparser.api.Authorship a) {
+    return a == null || a.isEmpty() ? null : a.toString();
+  }
+
+  private static String year(org.gbif.nameparser.api.Authorship a) {
+    return a == null ? null : a.getYear();
+  }
 }

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -8,6 +8,9 @@ import life.catalogue.parser.Parser;
 import life.catalogue.parser.SafeParser;
 import life.catalogue.resources.matching.openrefine.OpenRefineModel;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 
 /** Pure mapping between the CoL parsers and the OpenRefine reconciliation protocol. */
@@ -67,7 +70,7 @@ public class ParserOpenRefineMapper {
 
   public static final OpenRefineModel.Type NAME_TYPE = new OpenRefineModel.Type("Name", "Name");
 
-  public static final java.util.List<OpenRefineModel.ExtendProperty> NAME_PROPERTIES = java.util.List.of(
+  public static final List<OpenRefineModel.ExtendProperty> NAME_PROPERTIES = List.of(
     new OpenRefineModel.ExtendProperty("label", "label"),
     new OpenRefineModel.ExtendProperty("labelHtml", "label (HTML)"),
     new OpenRefineModel.ExtendProperty("scientificName", "scientific name"),
@@ -94,13 +97,13 @@ public class ParserOpenRefineMapper {
   public static OpenRefineModel.Manifest nameManifest(String apiReconcileUrl, String clbBaseUrl) {
     var m = new OpenRefineModel.Manifest();
     m.name = "Catalogue of Life — name parser";
-    String space = org.apache.commons.lang3.StringUtils.removeEnd(clbBaseUrl, "/") + "/tools/name-parser";
+    String space = StringUtils.removeEnd(clbBaseUrl, "/") + "/tools/name-parser";
     m.identifierSpace = space;
     m.schemaSpace = space;
     m.defaultTypes.add(NAME_TYPE);
     var extend = new OpenRefineModel.ExtendService(
       new OpenRefineModel.PropertySettings(apiReconcileUrl, "/extend/propose"));
-    extend.property_settings = java.util.List.of(codeSetting(), rankSetting());
+    extend.property_settings = List.of(codeSetting(), rankSetting());
     m.extend = extend;
     return m;
   }
@@ -165,7 +168,7 @@ public class ParserOpenRefineMapper {
 
   public static final OpenRefineModel.Type GEOTIME_TYPE = new OpenRefineModel.Type("GeoTime", "GeoTime");
 
-  public static final java.util.List<OpenRefineModel.ExtendProperty> GEOTIME_PROPERTIES = java.util.List.of(
+  public static final List<OpenRefineModel.ExtendProperty> GEOTIME_PROPERTIES = List.of(
     new OpenRefineModel.ExtendProperty("name", "name"),
     new OpenRefineModel.ExtendProperty("type", "type"),
     new OpenRefineModel.ExtendProperty("start", "start (Ma)"),
@@ -175,7 +178,7 @@ public class ParserOpenRefineMapper {
   public static OpenRefineModel.Manifest geoTimeManifest(String apiReconcileUrl, String clbBaseUrl) {
     var m = new OpenRefineModel.Manifest();
     m.name = "Catalogue of Life — geochronology (GeoTime)";
-    String space = org.apache.commons.lang3.StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/geotime";
+    String space = StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/geotime";
     m.identifierSpace = space; m.schemaSpace = space;
     m.defaultTypes.add(GEOTIME_TYPE);
     m.suggest = new OpenRefineModel.SuggestServices();
@@ -212,7 +215,7 @@ public class ParserOpenRefineMapper {
 
   public static final OpenRefineModel.Type TAXGROUP_TYPE = new OpenRefineModel.Type("TaxGroup", "TaxGroup");
 
-  public static final java.util.List<OpenRefineModel.ExtendProperty> TAXGROUP_PROPERTIES = java.util.List.of(
+  public static final List<OpenRefineModel.ExtendProperty> TAXGROUP_PROPERTIES = List.of(
     new OpenRefineModel.ExtendProperty("parent", "parent group"),
     new OpenRefineModel.ExtendProperty("codes", "nomenclatural codes"),
     new OpenRefineModel.ExtendProperty("description", "description"),
@@ -222,7 +225,7 @@ public class ParserOpenRefineMapper {
   public static OpenRefineModel.Manifest taxGroupManifest(String apiReconcileUrl, String clbBaseUrl) {
     var m = new OpenRefineModel.Manifest();
     m.name = "Catalogue of Life — taxonomic group";
-    String space = org.apache.commons.lang3.StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/taxgroup";
+    String space = StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/taxgroup";
     m.identifierSpace = space; m.schemaSpace = space;
     m.defaultTypes.add(TAXGROUP_TYPE);
     m.suggest = new OpenRefineModel.SuggestServices();
@@ -240,7 +243,7 @@ public class ParserOpenRefineMapper {
     switch (pid) {
       case "parent": return g.getPrimaryParent() == null ? null : g.getPrimaryParent().name();
       case "codes": return g.getCodes() == null || g.getCodes().isEmpty() ? null :
-        g.getCodes().stream().map(Enum::name).collect(java.util.stream.Collectors.joining(";"));
+        g.getCodes().stream().map(Enum::name).collect(Collectors.joining(";"));
       case "description": return g.getDescription();
       case "icon": return g.getIconSVG() == null ? null : g.getIconSVG().toString();
       default: return null;
@@ -249,7 +252,7 @@ public class ParserOpenRefineMapper {
 
   public static final OpenRefineModel.Type AREA_TYPE = new OpenRefineModel.Type("Area", "Area");
 
-  public static final java.util.List<OpenRefineModel.ExtendProperty> AREA_PROPERTIES = java.util.List.of(
+  public static final List<OpenRefineModel.ExtendProperty> AREA_PROPERTIES = List.of(
     new OpenRefineModel.ExtendProperty("gazetteer", "gazetteer"),
     new OpenRefineModel.ExtendProperty("id", "id"),
     new OpenRefineModel.ExtendProperty("name", "name"),

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -1,5 +1,6 @@
 package life.catalogue.resources.parser.openrefine;
 
+import life.catalogue.api.vocab.GeoTime;
 import life.catalogue.parser.Parser;
 import life.catalogue.parser.SafeParser;
 import life.catalogue.resources.matching.openrefine.OpenRefineModel;
@@ -183,7 +184,7 @@ public class ParserOpenRefineMapper {
   public static OpenRefineModel.SuggestResponse geoTimeSuggest(String prefix, int limit) {
     var resp = new OpenRefineModel.SuggestResponse();
     String p = prefix == null ? "" : prefix.toLowerCase();
-    for (var gt : life.catalogue.api.vocab.GeoTime.TIMES.values()) {
+    for (GeoTime gt : GeoTime.TIMES.values()) {
       if (resp.result.size() >= limit) break;
       if (p.isEmpty() || gt.getName().toLowerCase().startsWith(p)) {
         var item = new OpenRefineModel.SuggestItem();
@@ -195,7 +196,7 @@ public class ParserOpenRefineMapper {
     return resp;
   }
 
-  public static String geoTimeValue(life.catalogue.api.vocab.GeoTime gt, String pid) {
+  public static String geoTimeValue(GeoTime gt, String pid) {
     if (gt == null || pid == null) return null;
     switch (pid) {
       case "name": return gt.getName();

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -158,4 +158,51 @@ public class ParserOpenRefineMapper {
   private static String year(org.gbif.nameparser.api.Authorship a) {
     return a == null ? null : a.getYear();
   }
+
+  public static final OpenRefineModel.Type GEOTIME_TYPE = new OpenRefineModel.Type("GeoTime", "GeoTime");
+
+  public static final java.util.List<OpenRefineModel.ExtendProperty> GEOTIME_PROPERTIES = java.util.List.of(
+    new OpenRefineModel.ExtendProperty("name", "name"),
+    new OpenRefineModel.ExtendProperty("type", "type"),
+    new OpenRefineModel.ExtendProperty("start", "start (Ma)"),
+    new OpenRefineModel.ExtendProperty("end", "end (Ma)")
+  );
+
+  public static OpenRefineModel.Manifest geoTimeManifest(String apiReconcileUrl, String clbBaseUrl) {
+    var m = new OpenRefineModel.Manifest();
+    m.name = "Catalogue of Life — geochronology (GeoTime)";
+    String space = org.apache.commons.lang3.StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/geotime";
+    m.identifierSpace = space; m.schemaSpace = space;
+    m.defaultTypes.add(GEOTIME_TYPE);
+    m.suggest = new OpenRefineModel.SuggestServices();
+    m.suggest.entity = new OpenRefineModel.SuggestService(apiReconcileUrl, "/suggest/entity");
+    m.extend = new OpenRefineModel.ExtendService(new OpenRefineModel.PropertySettings(apiReconcileUrl, "/extend/propose"));
+    return m;
+  }
+
+  public static OpenRefineModel.SuggestResponse geoTimeSuggest(String prefix, int limit) {
+    var resp = new OpenRefineModel.SuggestResponse();
+    String p = prefix == null ? "" : prefix.toLowerCase();
+    for (var gt : life.catalogue.api.vocab.GeoTime.TIMES.values()) {
+      if (resp.result.size() >= limit) break;
+      if (p.isEmpty() || gt.getName().toLowerCase().startsWith(p)) {
+        var item = new OpenRefineModel.SuggestItem();
+        item.id = gt.getName(); item.name = gt.getName();
+        item.description = gt.getType() == null ? null : gt.getType().name();
+        resp.result.add(item);
+      }
+    }
+    return resp;
+  }
+
+  public static String geoTimeValue(life.catalogue.api.vocab.GeoTime gt, String pid) {
+    if (gt == null || pid == null) return null;
+    switch (pid) {
+      case "name": return gt.getName();
+      case "type": return gt.getType() == null ? null : gt.getType().name();
+      case "start": return gt.getStart() == null ? null : String.valueOf(gt.getStart());
+      case "end": return gt.getEnd() == null ? null : String.valueOf(gt.getEnd());
+      default: return null;
+    }
+  }
 }

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapper.java
@@ -1,6 +1,7 @@
 package life.catalogue.resources.parser.openrefine;
 
 import life.catalogue.api.vocab.GeoTime;
+import life.catalogue.api.vocab.TaxGroup;
 import life.catalogue.parser.Parser;
 import life.catalogue.parser.SafeParser;
 import life.catalogue.resources.matching.openrefine.OpenRefineModel;
@@ -203,6 +204,43 @@ public class ParserOpenRefineMapper {
       case "type": return gt.getType() == null ? null : gt.getType().name();
       case "start": return gt.getStart() == null ? null : String.valueOf(gt.getStart());
       case "end": return gt.getEnd() == null ? null : String.valueOf(gt.getEnd());
+      default: return null;
+    }
+  }
+
+  public static final OpenRefineModel.Type TAXGROUP_TYPE = new OpenRefineModel.Type("TaxGroup", "TaxGroup");
+
+  public static final java.util.List<OpenRefineModel.ExtendProperty> TAXGROUP_PROPERTIES = java.util.List.of(
+    new OpenRefineModel.ExtendProperty("parent", "parent group"),
+    new OpenRefineModel.ExtendProperty("codes", "nomenclatural codes"),
+    new OpenRefineModel.ExtendProperty("description", "description"),
+    new OpenRefineModel.ExtendProperty("icon", "icon URL")
+  );
+
+  public static OpenRefineModel.Manifest taxGroupManifest(String apiReconcileUrl, String clbBaseUrl) {
+    var m = new OpenRefineModel.Manifest();
+    m.name = "Catalogue of Life — taxonomic group";
+    String space = org.apache.commons.lang3.StringUtils.removeEnd(clbBaseUrl, "/") + "/vocabulary/taxgroup";
+    m.identifierSpace = space; m.schemaSpace = space;
+    m.defaultTypes.add(TAXGROUP_TYPE);
+    m.suggest = new OpenRefineModel.SuggestServices();
+    m.suggest.entity = new OpenRefineModel.SuggestService(apiReconcileUrl, "/suggest/entity");
+    m.extend = new OpenRefineModel.ExtendService(new OpenRefineModel.PropertySettings(apiReconcileUrl, "/extend/propose"));
+    return m;
+  }
+
+  public static OpenRefineModel.SuggestResponse taxGroupSuggest(String prefix, int limit) {
+    return enumSuggest(TaxGroup.class, prefix, limit);
+  }
+
+  public static String taxGroupValue(TaxGroup g, String pid) {
+    if (g == null || pid == null) return null;
+    switch (pid) {
+      case "parent": return g.getPrimaryParent() == null ? null : g.getPrimaryParent().name();
+      case "codes": return g.getCodes() == null || g.getCodes().isEmpty() ? null :
+        g.getCodes().stream().map(Enum::name).collect(java.util.stream.Collectors.joining(";"));
+      case "description": return g.getDescription();
+      case "icon": return g.getIconSVG() == null ? null : g.getIconSVG().toString();
       default: return null;
     }
   }

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/TaxGroupReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/TaxGroupReconciliationResource.java
@@ -1,0 +1,79 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.api.vocab.TaxGroup;
+import life.catalogue.matching.TaxGroupAnalyzer;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+import life.catalogue.resources.matching.openrefine.OpenRefineQueries;
+
+import java.net.URI;
+import java.util.List;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+@Path("/parser/taxgroup/reconcile")
+public class TaxGroupReconciliationResource extends AbstractParserReconciliationResource {
+  private final TaxGroupAnalyzer analyzer = new TaxGroupAnalyzer();
+
+  public TaxGroupReconciliationResource(URI apiURI, URI clbURI) {
+    super(apiURI, clbURI);
+  }
+
+  @Override
+  protected String typePath() {
+    return "taxgroup";
+  }
+
+  @Override
+  protected OpenRefineModel.Manifest manifest(String reconcileBaseUrl, String clbBase) {
+    return ParserOpenRefineMapper.taxGroupManifest(reconcileBaseUrl, clbBase);
+  }
+
+  @Override
+  protected OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, MultivaluedMap<String, String> params) {
+    var result = new OpenRefineModel.Result();
+    var sn = OpenRefineQueries.toSimpleName(q);
+    if (sn != null) {
+      TaxGroup g = analyzer.analyze(sn, sn.getClassification() == null ? java.util.List.of() : sn.getClassification());
+      if (g != null && !g.isOther()) {
+        var c = new OpenRefineModel.Candidate();
+        c.id = g.name();
+        c.name = g.name();
+        c.score = 100;
+        c.match = true;
+        c.type.add(ParserOpenRefineMapper.TAXGROUP_TYPE);
+        result.result.add(c);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  protected List<OpenRefineModel.ExtendProperty> extendProperties() {
+    return ParserOpenRefineMapper.TAXGROUP_PROPERTIES;
+  }
+
+  @Override
+  protected String proposeType() {
+    return "TaxGroup";
+  }
+
+  @Override
+  protected String extendValue(String id, OpenRefineModel.ExtendProperty p, MultivaluedMap<String, String> params) {
+    return ParserOpenRefineMapper.taxGroupValue(parse(id), p.id);
+  }
+
+  @Override
+  protected OpenRefineModel.SuggestResponse suggestEntity(String prefix) {
+    return ParserOpenRefineMapper.taxGroupSuggest(prefix, SUGGEST_LIMIT);
+  }
+
+  private static TaxGroup parse(String id) {
+    if (id == null) return null;
+    try {
+      return TaxGroup.valueOf(id);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/VocabReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/VocabReconciliationResource.java
@@ -1,0 +1,112 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.api.jackson.ApiModule;
+import life.catalogue.parser.EnumParser;
+import life.catalogue.parser.Parser;
+import life.catalogue.parser.Parsers;
+import life.catalogue.resources.matching.openrefine.OpenRefineMapper;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+/** OpenRefine reconciliation for the controlled-vocabulary parsers, one service per {type}. */
+@Path("/parser/{type}/reconcile")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class VocabReconciliationResource {
+  private static final int SUGGEST_LIMIT = 25;
+  // handled by dedicated resources, never by the generic one
+  private static final Set<String> RESERVED = Set.of("name", "geotime", "taxgroup", "area");
+  private final URI apiURI;
+  private final URI clbURI;
+
+  public VocabReconciliationResource(URI apiURI, URI clbURI) {
+    this.apiURI = apiURI;
+    this.clbURI = clbURI;
+  }
+
+  private Parser<?> parserOr404(String type) {
+    if (type != null && !RESERVED.contains(type.toLowerCase())) {
+      Parser<?> p = Parsers.get(type);
+      if (p != null) return p;
+    }
+    throw new NotFoundException("No reconciliation parser for " + type);
+  }
+
+  private String reconcileBaseUrl(String type) {
+    return (apiURI == null ? "" : StringUtils.removeEnd(apiURI.toString(), "/")) + "/parser/" + type + "/reconcile";
+  }
+
+  private String clbBase() {
+    return clbURI == null ? "https://www.checklistbank.org" : StringUtils.removeEnd(clbURI.toString(), "/");
+  }
+
+  @GET
+  public Object root(@PathParam("type") String type, @QueryParam("queries") String queries) {
+    Parser<?> parser = parserOr404(type);
+    if (queries == null) {
+      boolean enumBacked = parser instanceof EnumParser;
+      return ParserOpenRefineMapper.vocabManifest(type.toLowerCase(), reconcileBaseUrl(type.toLowerCase()), clbBase(), enumBacked);
+    }
+    return reconcile(parser, type, queries);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  public Map<String, OpenRefineModel.Result> reconcileForm(@PathParam("type") String type, @FormParam("queries") String queries) {
+    return reconcile(parserOr404(type), type, queries);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Map<String, OpenRefineModel.Result> reconcileJson(@PathParam("type") String type, String body) {
+    String queries = body;
+    try {
+      JsonNode node = ApiModule.MAPPER.readTree(body);
+      if (node != null && node.has("queries")) {
+        queries = node.get("queries").toString();
+      }
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid JSON body: " + e.getMessage());
+    }
+    return reconcile(parserOr404(type), type, queries);
+  }
+
+  private Map<String, OpenRefineModel.Result> reconcile(Parser<?> parser, String type, String queriesJson) {
+    Map<String, OpenRefineModel.Query> queries;
+    try {
+      queries = OpenRefineMapper.parseQueries(queriesJson, ApiModule.MAPPER);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid queries payload: " + e.getMessage());
+    }
+    Map<String, OpenRefineModel.Result> out = new LinkedHashMap<>();
+    for (var e : queries.entrySet()) {
+      var q = e.getValue();
+      out.put(e.getKey(), q == null || StringUtils.isBlank(q.query)
+        ? new OpenRefineModel.Result()
+        : ParserOpenRefineMapper.vocabResult(parser, q.query));
+    }
+    return out;
+  }
+
+  @GET
+  @Path("suggest/entity")
+  public OpenRefineModel.SuggestResponse suggestEntity(@PathParam("type") String type, @QueryParam("prefix") String prefix) {
+    Parser<?> parser = parserOr404(type);
+    if (parser instanceof EnumParser) {
+      return ParserOpenRefineMapper.enumSuggest(((EnumParser<?>) parser).getEnumClass(), prefix, SUGGEST_LIMIT);
+    }
+    return new OpenRefineModel.SuggestResponse();
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/parser/openrefine/VocabReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/parser/openrefine/VocabReconciliationResource.java
@@ -95,7 +95,7 @@ public class VocabReconciliationResource {
       var q = e.getValue();
       out.put(e.getKey(), q == null || StringUtils.isBlank(q.query)
         ? new OpenRefineModel.Result()
-        : ParserOpenRefineMapper.vocabResult(parser, q.query));
+        : ParserOpenRefineMapper.vocabResult(parser, type.toLowerCase(), q.query));
     }
     return out;
   }
@@ -107,6 +107,6 @@ public class VocabReconciliationResource {
     if (parser instanceof EnumParser) {
       return ParserOpenRefineMapper.enumSuggest(((EnumParser<?>) parser).getEnumClass(), prefix, SUGGEST_LIMIT);
     }
-    return new OpenRefineModel.SuggestResponse();
+    throw new NotFoundException("No suggest for " + type);
   }
 }

--- a/webservice/src/test/java/life/catalogue/resources/matching/openrefine/OpenRefineQueriesTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/matching/openrefine/OpenRefineQueriesTest.java
@@ -2,6 +2,7 @@ package life.catalogue.resources.matching.openrefine;
 
 import life.catalogue.api.jackson.ApiModule;
 
+import org.gbif.nameparser.api.NomCode;
 import org.gbif.nameparser.api.Rank;
 
 import org.junit.Test;
@@ -24,5 +25,18 @@ public class OpenRefineQueriesTest {
   public void blankQueryIsNull() {
     var q = new OpenRefineModel.Query();
     assertNull(OpenRefineQueries.toSimpleName(q));
+  }
+
+  @Test
+  public void buildsNameWithCodeAndClassification() throws Exception {
+    String json = "{\"query\":\"Puma concolor\",\"properties\":[" +
+      "{\"pid\":\"code\",\"v\":\"ICZN\"},{\"pid\":\"family\",\"v\":\"Felidae\"}]}";
+    var q = ApiModule.MAPPER.readValue(json, OpenRefineModel.Query.class);
+    var sn = OpenRefineQueries.toSimpleName(q);
+    assertEquals(NomCode.ZOOLOGICAL, sn.getCode());
+    assertNotNull(sn.getClassification());
+    assertEquals(1, sn.getClassification().size());
+    assertEquals("Felidae", sn.getClassification().get(0).getName());
+    assertEquals(Rank.FAMILY, sn.getClassification().get(0).getRank());
   }
 }

--- a/webservice/src/test/java/life/catalogue/resources/matching/openrefine/OpenRefineQueriesTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/matching/openrefine/OpenRefineQueriesTest.java
@@ -1,0 +1,28 @@
+package life.catalogue.resources.matching.openrefine;
+
+import life.catalogue.api.jackson.ApiModule;
+
+import org.gbif.nameparser.api.Rank;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OpenRefineQueriesTest {
+  @Test
+  public void buildsNameWithHints() throws Exception {
+    String json = "{\"query\":\"Puma concolor\",\"properties\":[" +
+      "{\"pid\":\"authorship\",\"v\":\"Linnaeus, 1771\"},{\"pid\":\"rank\",\"v\":\"species\"}]}";
+    var q = ApiModule.MAPPER.readValue(json, OpenRefineModel.Query.class);
+    var sn = OpenRefineQueries.toSimpleName(q);
+    assertEquals("Puma concolor", sn.getName());
+    assertEquals("Linnaeus, 1771", sn.getAuthorship());
+    assertEquals(Rank.SPECIES, sn.getRank());
+  }
+
+  @Test
+  public void blankQueryIsNull() {
+    var q = new OpenRefineModel.Query();
+    assertNull(OpenRefineQueries.toSimpleName(q));
+  }
+}

--- a/webservice/src/test/java/life/catalogue/resources/matching/openrefine/ParserOpenRefineModelTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/matching/openrefine/ParserOpenRefineModelTest.java
@@ -1,7 +1,6 @@
-package life.catalogue.resources.parser.openrefine;
+package life.catalogue.resources.matching.openrefine;
 
 import life.catalogue.api.jackson.ApiModule;
-import life.catalogue.resources.matching.openrefine.OpenRefineModel;
 
 import java.util.List;
 
@@ -19,12 +18,14 @@ public class ParserOpenRefineModelTest {
     code.name = "code";
     code.label = "Nomenclatural code";
     code.type = "select";
+    code.default_ = "ICZN";
     code.choices = List.of(new OpenRefineModel.SettingChoice("ICZN", "Zoological (ICZN)"));
     svc.property_settings = List.of(code);
 
     String json = ApiModule.MAPPER.writeValueAsString(svc);
     assertTrue(json.contains("\"property_settings\""));
     assertTrue(json.contains("\"ICZN\""));
+    assertTrue(json.contains("\"default\""));
   }
 
   @Test

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/NameReconciliationResourceTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/NameReconciliationResourceTest.java
@@ -1,0 +1,33 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NameReconciliationResourceTest {
+  private final NameReconciliationResource res = new NameReconciliationResource(null, null);
+
+  private OpenRefineModel.Query q(String query) {
+    var x = new OpenRefineModel.Query();
+    x.query = query;
+    return x;
+  }
+
+  @Test
+  public void parsableNameAutoMatches() {
+    var r = res.reconcileSingle(q("Abies alba Mill."), new MultivaluedHashMap<>());
+    assertEquals(1, r.result.size());
+    assertTrue(r.result.get(0).match);
+    assertEquals(100.0, r.result.get(0).score, 0.0001);
+  }
+
+  @Test
+  public void unparsableNameHasNoCandidate() {
+    var r = res.reconcileSingle(q("?? not a name 12345 ##"), new MultivaluedHashMap<>());
+    assertTrue("unparsable input must yield no candidate", r.result.isEmpty());
+  }
+}

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -97,6 +97,13 @@ public class ParserOpenRefineMapperTest {
   }
 
   @Test
+  public void areaManifestHasExtendNoSuggest() {
+    var m = ParserOpenRefineMapper.areaManifest("http://x/parser/area/reconcile", "http://clb");
+    assertNull(m.suggest);
+    assertNotNull(m.extend);
+  }
+
+  @Test
   public void areaResultUsesGlobalId() {
     var r = ParserOpenRefineMapper.areaResult("tdwg:14");
     assertEquals(1, r.result.size());

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -42,4 +42,29 @@ public class ParserOpenRefineMapperTest {
     assertNotNull(m2.suggest);
     assertNotNull(m2.suggest.entity);
   }
+
+  @Test
+  public void nameExtendValuesWithCode() throws Exception {
+    var pnu = life.catalogue.parser.NameParser.PARSER
+      .parse("Abies alba", "Mill.", org.gbif.nameparser.api.Rank.SPECIES,
+             org.gbif.nameparser.api.NomCode.BOTANICAL, life.catalogue.api.model.IssueContainer.VOID)
+      .get();
+    var n = pnu.getName();
+    assertEquals("alba", ParserOpenRefineMapper.nameValue(n, pnu, "specificEpithet"));
+    assertEquals("Abies", ParserOpenRefineMapper.nameValue(n, pnu, "genus"));
+    assertEquals("species", ParserOpenRefineMapper.nameValue(n, pnu, "rank"));
+    assertNotNull(ParserOpenRefineMapper.nameValue(n, pnu, "label"));
+    assertNotNull(ParserOpenRefineMapper.nameValue(n, pnu, "labelHtml"));
+    assertEquals("true", ParserOpenRefineMapper.nameValue(n, pnu, "parsed"));
+  }
+
+  @Test
+  public void nameManifestHasCodeAndRankSettings() {
+    var m = ParserOpenRefineMapper.nameManifest("http://x/parser/name/reconcile", "http://clb");
+    assertNull(m.suggest);
+    assertNotNull(m.extend);
+    assertNotNull(m.extend.property_settings);
+    assertTrue(m.extend.property_settings.stream().anyMatch(s -> s.name.equals("code")));
+    assertTrue(m.extend.property_settings.stream().anyMatch(s -> s.name.equals("rank")));
+  }
 }

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -75,6 +75,7 @@ public class ParserOpenRefineMapperTest {
     assertEquals(gt.getName(), ParserOpenRefineMapper.geoTimeValue(gt, "name"));
     assertNotNull(ParserOpenRefineMapper.geoTimeValue(gt, "type"));
     assertNotNull(ParserOpenRefineMapper.geoTimeValue(gt, "end"));
+    assertNotNull(ParserOpenRefineMapper.geoTimeValue(gt, "start"));
   }
 
   @Test

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -67,4 +67,19 @@ public class ParserOpenRefineMapperTest {
     assertTrue(m.extend.property_settings.stream().anyMatch(s -> s.name.equals("code")));
     assertTrue(m.extend.property_settings.stream().anyMatch(s -> s.name.equals("rank")));
   }
+
+  @Test
+  public void geoTimeExtendValues() {
+    var gt = life.catalogue.api.vocab.GeoTime.byName("Holocene");
+    assertNotNull(gt);
+    assertEquals(gt.getName(), ParserOpenRefineMapper.geoTimeValue(gt, "name"));
+    assertNotNull(ParserOpenRefineMapper.geoTimeValue(gt, "type"));
+    assertNotNull(ParserOpenRefineMapper.geoTimeValue(gt, "end"));
+  }
+
+  @Test
+  public void geoTimeSuggestByPrefix() {
+    var resp = ParserOpenRefineMapper.geoTimeSuggest("holo", 25);
+    assertTrue(resp.result.stream().anyMatch(i -> i.name.toLowerCase().startsWith("holo")));
+  }
 }

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -83,4 +83,16 @@ public class ParserOpenRefineMapperTest {
     var resp = ParserOpenRefineMapper.geoTimeSuggest("holo", 25);
     assertTrue(resp.result.stream().anyMatch(i -> i.name.toLowerCase().startsWith("holo")));
   }
+
+  @Test
+  public void taxGroupExtendValues() {
+    var g = life.catalogue.api.vocab.TaxGroup.Viruses;
+    assertNotNull(ParserOpenRefineMapper.taxGroupValue(g, "codes")); // NomCode.VIRUS
+  }
+
+  @Test
+  public void taxGroupSuggestByPrefix() {
+    var resp = ParserOpenRefineMapper.taxGroupSuggest("vir", 25);
+    assertTrue(resp.result.stream().anyMatch(i -> i.id.equals(life.catalogue.api.vocab.TaxGroup.Viruses.name())));
+  }
 }

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -13,7 +13,7 @@ public class ParserOpenRefineMapperTest {
 
   @Test
   public void vocabResultAutoMatchesEnum() {
-    OpenRefineModel.Result r = ParserOpenRefineMapper.vocabResult(RankParser.PARSER, "sp.");
+    OpenRefineModel.Result r = ParserOpenRefineMapper.vocabResult(RankParser.PARSER, "rank", "sp.");
     assertEquals(1, r.result.size());
     var c = r.result.get(0);
     assertEquals(Rank.SPECIES.name(), c.id); // "SPECIES"
@@ -23,7 +23,7 @@ public class ParserOpenRefineMapperTest {
 
   @Test
   public void vocabResultEmptyWhenUnparsable() {
-    OpenRefineModel.Result r = ParserOpenRefineMapper.vocabResult(RankParser.PARSER, "@@@nonsense@@@");
+    OpenRefineModel.Result r = ParserOpenRefineMapper.vocabResult(RankParser.PARSER, "rank", "@@@nonsense@@@");
     assertTrue(r.result.isEmpty());
   }
 

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -95,4 +95,26 @@ public class ParserOpenRefineMapperTest {
     var resp = ParserOpenRefineMapper.taxGroupSuggest("vir", 25);
     assertTrue(resp.result.stream().anyMatch(i -> i.id.equals(life.catalogue.api.vocab.TaxGroup.Viruses.name())));
   }
+
+  @Test
+  public void areaResultUsesGlobalId() {
+    var r = ParserOpenRefineMapper.areaResult("tdwg:14");
+    assertEquals(1, r.result.size());
+    assertEquals("tdwg:14", r.result.get(0).id);
+    assertTrue(r.result.get(0).match);
+  }
+
+  @Test
+  public void areaFreeTextHasNoCandidate() {
+    var r = ParserOpenRefineMapper.areaResult("Germany"); // TEXT area, no globalId
+    assertTrue(r.result.isEmpty());
+  }
+
+  @Test
+  public void areaExtendValues() throws Exception {
+    var a = life.catalogue.parser.AreaParser.PARSER.parse("tdwg:14").orElse(null);
+    assertNotNull(a);
+    assertEquals("tdwg:14", ParserOpenRefineMapper.areaValue(a, "globalId"));
+    assertNotNull(ParserOpenRefineMapper.areaValue(a, "gazetteer"));
+  }
 }

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineMapperTest.java
@@ -1,0 +1,45 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.parser.RankParser;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import org.gbif.nameparser.api.Rank;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ParserOpenRefineMapperTest {
+
+  @Test
+  public void vocabResultAutoMatchesEnum() {
+    OpenRefineModel.Result r = ParserOpenRefineMapper.vocabResult(RankParser.PARSER, "sp.");
+    assertEquals(1, r.result.size());
+    var c = r.result.get(0);
+    assertEquals(Rank.SPECIES.name(), c.id); // "SPECIES"
+    assertTrue(c.match);
+    assertEquals(100.0, c.score, 0.0001);
+  }
+
+  @Test
+  public void vocabResultEmptyWhenUnparsable() {
+    OpenRefineModel.Result r = ParserOpenRefineMapper.vocabResult(RankParser.PARSER, "@@@nonsense@@@");
+    assertTrue(r.result.isEmpty());
+  }
+
+  @Test
+  public void enumSuggestFiltersByPrefix() {
+    var resp = ParserOpenRefineMapper.enumSuggest(Rank.class, "spec", 25);
+    assertTrue(resp.result.stream().anyMatch(i -> i.id.equals(Rank.SPECIES.name())));
+    assertTrue(resp.result.stream().noneMatch(i -> i.id.equals(Rank.GENUS.name())));
+  }
+
+  @Test
+  public void vocabManifestOmitsSuggestWhenNotEnum() {
+    var m = ParserOpenRefineMapper.vocabManifest("uri", "http://x/parser/uri/reconcile", "http://clb", false);
+    assertNull(m.suggest);
+    var m2 = ParserOpenRefineMapper.vocabManifest("rank", "http://x/parser/rank/reconcile", "http://clb", true);
+    assertNotNull(m2.suggest);
+    assertNotNull(m2.suggest.entity);
+  }
+}

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineModelTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/ParserOpenRefineModelTest.java
@@ -1,0 +1,39 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.api.jackson.ApiModule;
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ParserOpenRefineModelTest {
+
+  @Test
+  public void extendServiceCarriesPropertySettings() throws Exception {
+    var svc = new OpenRefineModel.ExtendService(
+      new OpenRefineModel.PropertySettings("http://x/parser/name/reconcile", "/extend/propose"));
+    var code = new OpenRefineModel.PropertySetting();
+    code.name = "code";
+    code.label = "Nomenclatural code";
+    code.type = "select";
+    code.choices = List.of(new OpenRefineModel.SettingChoice("ICZN", "Zoological (ICZN)"));
+    svc.property_settings = List.of(code);
+
+    String json = ApiModule.MAPPER.writeValueAsString(svc);
+    assertTrue(json.contains("\"property_settings\""));
+    assertTrue(json.contains("\"ICZN\""));
+  }
+
+  @Test
+  public void extendPropertyParsesSettings() throws Exception {
+    String body = "{\"id\":\"genus\",\"settings\":{\"code\":\"ICZN\",\"rank\":\"species\"}}";
+    var p = ApiModule.MAPPER.readValue(body, OpenRefineModel.ExtendProperty.class);
+    assertEquals("genus", p.id);
+    assertNotNull(p.settings);
+    assertEquals("ICZN", p.settings.get("code").asText());
+    assertEquals("species", p.settings.get("rank").asText());
+  }
+}

--- a/webservice/src/test/java/life/catalogue/resources/parser/openrefine/VocabReconciliationResourceTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/parser/openrefine/VocabReconciliationResourceTest.java
@@ -1,0 +1,33 @@
+package life.catalogue.resources.parser.openrefine;
+
+import life.catalogue.resources.matching.openrefine.OpenRefineModel;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+import jakarta.ws.rs.NotFoundException;
+
+import static org.junit.Assert.*;
+
+public class VocabReconciliationResourceTest {
+  private final VocabReconciliationResource res =
+    new VocabReconciliationResource(URI.create("http://api"), URI.create("http://clb"));
+
+  @Test(expected = NotFoundException.class)
+  public void reservedTypeIs404() {
+    res.root("name", null); // name handled by dedicated resource
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void unknownTypeIs404() {
+    res.root("does-not-exist", null);
+  }
+
+  @Test
+  public void enumManifestHasSuggest() {
+    Object m = res.root("rank", null);
+    assertTrue(m instanceof OpenRefineModel.Manifest);
+    assertNotNull(((OpenRefineModel.Manifest) m).suggest);
+  }
+}


### PR DESCRIPTION
Adds OpenRefine Reconciliation Service API (spec 0.2) endpoints over the ChecklistBank parsers, complementing the existing taxon/name-usage reconciliation.

## What's new

| Endpoint | Behaviour |
|---|---|
| `GET/POST /parser/{type}/reconcile` | Generic service for the enum/controlled-vocabulary parsers (rank, country, language, nomstatus, …). Auto-matches a clean parse to the canonical enum constant; enum-backed types also offer `suggest/entity`. |
| `/parser/name/reconcile` | Name parser: thin reconcile (parsable names only) + data extension exposing all parsed components (`label`, `genus`, `specificEpithet`, `authorship`, `rank`, …), with `code`/`rank` context via per-property extend settings or `?code=&rank=` query params. |
| `/parser/geotime/reconcile` | GeoTime: reconcile + suggest + extend (`name, type, start, end`). |
| `/parser/taxgroup/reconcile` | TaxGroup via `TaxGroupAnalyzer` (query = scientific name + optional rank/code/classification hints) + suggest + extend (`parent, codes, description, icon`). |
| `/parser/area/reconcile` | Area CURIEs (`tdwg:14`, `mrgid:…`, `iso:…`) → canonical gazetteer area + extend (`gazetteer, id, name, globalId, link`); free-text areas left unmatched. |

The four dedicated resources share a new `AbstractParserReconciliationResource` (HTTP plumbing) and a pure `ParserOpenRefineMapper` (mapping). Registered on the read-only server, and the name service is also registered on the matching server.

## Supporting refactors (behaviour-preserving)

- `Parsers` — shared parser registry extracted from `ParserResource` (keeps `/parser` behaviour incl. `area`/`geotime`).
- `OpenRefineQueries` — shared OpenRefine query → `SimpleNameClassified` builder extracted from `AbstractReconciliationResource`.
- `OpenRefineModel` — backward-compatible additions (`ExtendService.property_settings`, `ExtendProperty.settings`, `PropertySetting`/`SettingChoice`); existing taxon reconciliation output unchanged.

## Notes

- Reconciliation auto-matches only on a clean parse (score 100); the name service rejects unparsable input via `NameType.isParsable()`.
- A user guide is added separately in the `checklistbank` repo (`/about/reconciliation`).

## Testing

New unit tests for the mapper, the name/vocab reconcile units, and routing (reserved/unknown type 404). Existing taxon reconciliation tests (`OpenRefineMapperTest`) unchanged → backward compatibility confirmed. Full `mvn verify` IT suite (Docker) not run locally.

Design spec & implementation plan: `docs/superpowers/{specs,plans}/2026-06-24-parser-openrefine-reconciliation*` (local, docs/ is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)