### PR TITLE
Upgrade build & runtime to JDK 25

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Catalogue of Life (CoL) Backend - A Dropwizard-based Java 21 application providing RESTful JSON webservices for ChecklistBank API (https://api.checklistbank.org/). 
+Catalogue of Life (CoL) Backend - A Dropwizard-based Java 25 application providing RESTful JSON webservices for ChecklistBank API (https://api.checklistbank.org/). 
 Manages taxonomic datasets with import, normalization, assembly, search indexing, and release management capabilities.
 
 ## Build & Test Commands
@@ -167,7 +167,7 @@ Follows Twitter Commons style guide with CoL customizations:
 - **Indent**: 2 spaces (1TBS brace style)
 - **Line limit**: 140 columns
 - **Naming**: CamelCase types, camelCase variables, UPPER_SNAKE constants
-- **Java version**: Java 21 (required)
+- **Java version**: Java 25 (required)
 - **Annotations**: Use `@Nullable` for nullable parameters/fields, `@VisibleForTesting` for test-only visibility
 - See `DEVELOPER-GUIDE.md` for comprehensive style guide
 
@@ -273,7 +273,7 @@ GET /dataset/{key}/export.zip?format=COLDP
 
 ## Prerequisites
 
-- Java 21 JDK
+- Java 25 JDK
 - Maven 3.9.5+
 - PostgreSQL 17
 - Elasticsearch 8.1.3 (optional, for name usage search)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   agent any
   tools {
     maven 'Maven 3.9.9'
-    jdk 'LibericaJDK21'
+    jdk 'LibericaJDK25'
   }
   options {
     disableConcurrentBuilds()

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>api</artifactId>

--- a/coldp/pom.xml
+++ b/coldp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>coldp</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>core</artifactId>

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.catalogueoflife</groupId>
 		<artifactId>motherpom</artifactId>
-		<version>1.2.3-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>dao</artifactId>

--- a/doi/pom.xml
+++ b/doi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>doi</artifactId>

--- a/importer/pom.xml
+++ b/importer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>importer</artifactId>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>metadata</artifactId>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser</artifactId>

--- a/pgcopy/pom.xml
+++ b/pgcopy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pgcopy</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
   <properties>
     <!-- build settings -->
     <minimumMavenVersion>3.9.5</minimumMavenVersion>
-    <java.version>21</java.version>
-    <java.maxVersion>21</java.maxVersion>
+    <java.version>25</java.version>
+    <java.maxVersion>25</java.maxVersion>
     <!-- .mvn/jvm.config is not being used by surefire - we need to replicate the settings here! -->
     <java.argLine>
       -Djdk.net.URLClassPath.disableClassPathURLCheck=true
@@ -86,9 +86,9 @@
     <junit.version>5.13.4</junit.version>
     <kryo.version>5.6.2</kryo.version>
     <kryo-reflectasm.version>1.11.9</kryo-reflectasm.version>
-    <lombok.version>1.18.30</lombok.version>
+    <lombok.version>1.18.46</lombok.version>
     <mapdb.version>3.1.0</mapdb.version>
-    <mockito.version>3.3.3</mockito.version>
+    <mockito.version>5.23.0</mockito.version>
     <mybatis.version>3.5.19</mybatis.version>
     <name-parser.version>3.16.0</name-parser.version>
     <newick-io.version>1.0.6</newick-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.catalogueoflife</groupId>
   <artifactId>motherpom</artifactId>
-  <version>1.2.3-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CLB motherpom</name>

--- a/reader-xls/pom.xml
+++ b/reader-xls/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>reader-xls</artifactId>

--- a/reader/pom.xml
+++ b/reader/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>reader</artifactId>

--- a/vocab/pom.xml
+++ b/vocab/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vocab</artifactId>

--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.catalogueoflife</groupId>
     <artifactId>motherpom</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>webservice</artifactId>
   <name>CLB WS</name>


### PR DESCRIPTION
Moves the backend from **Java 21** to **Java 25** (LTS → LTS).

## Changes
- `pom.xml`: `java.version` / `java.maxVersion` `21 → 25`
- `pom.xml`: **Mockito** `3.3.3 → 5.23.0` — Mockito 3's bundled Byte Buddy cannot instrument JDK 25 bytecode. No test code changes were needed (the suite uses none of the APIs removed in Mockito 4/5).
- `pom.xml`: **Lombok** `1.18.30 → 1.18.46` — transitive `gbif-api` annotation processor; ≤1.18.37 crashes javac on JDK 24/25.
- `Jenkinsfile`: `LibericaJDK21 → LibericaJDK25`
- `CLAUDE.md`: docs → Java 25

No application source changes were required.

## Verification (Liberica JDK 25.0.1)
- `mvn -T4 clean install -DskipTests` → **BUILD SUCCESS**, all 14 reactor modules compile; Lombok processor runs clean.
- `mvn verify` (full unit + TestContainers integration tests, **Postgres 17 + Elasticsearch 9**) → **BUILD SUCCESS**, every module green, **0 failures / 0 errors**.
- The main runtime risk — **Chronicle Map** (name-index in `dao`, usage-matcher in `core`, event queue) — is confirmed working on JDK 25 via its integration tests. Kryo `sun.misc.Unsafe` I/O, Fory, and the ES 9 client also work (Unsafe emits harmless deprecation warnings only).
- ✅ Confirmed green on Jenkins CI.

## Follow-ups (not in this PR — `deploy` repo / ops)
- Switch the app VMs' apt package `openjdk-21-jre-headless → openjdk-25-jre-headless` (prod + dev) and update the `GBIF.md` install note.
- The runtime `--add-opens` in `configs/{prod,dev}/jvm{,-ro}.args` + `cli-jvm.args` carry over unchanged — no new flags needed.
- Optional GC review: JDK 25 defaults differ from the 21-era tuning of the `-Xmx31g`/`-Xmx8g` heaps (currently no explicit GC flag → G1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)