### PR TITLE
fix(api): expose archived usages on the taxon info endpoint

### DIFF
--- a/core/src/test/java/life/catalogue/dao/TaxonDaoArchivedIT.java
+++ b/core/src/test/java/life/catalogue/dao/TaxonDaoArchivedIT.java
@@ -1,0 +1,107 @@
+package life.catalogue.dao;
+
+import life.catalogue.api.exception.ArchivedException;
+import life.catalogue.api.exception.NotFoundException;
+import life.catalogue.api.model.DSID;
+import life.catalogue.es.indexing.NameUsageIndexService;
+import life.catalogue.img.ThumborConfig;
+import life.catalogue.img.ThumborService;
+import life.catalogue.junit.PgSetupRule;
+import life.catalogue.junit.SqlSessionFactoryRule;
+import life.catalogue.junit.TestDataRule;
+import life.catalogue.matching.nidx.NameIndexFactory;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+import static org.junit.Assert.*;
+
+/**
+ * Verifies that ids which existed in an earlier release but were removed since are reported
+ * as archived - not as a plain 404 - so the portal can render a tombstone page.
+ * See https://github.com/CatalogueOfLife/data/issues/1644 where old OTU ids (BOLD BINs that
+ * were reissued under their source id) rendered a bare "not found" page instead.
+ */
+public class TaxonDaoArchivedIT {
+  static final int PROJECT_KEY = 3;
+  static final int RELEASE_KEY = 11;
+  // an id present in name_usage_archive.csv, but in no release usage table
+  static final String ARCHIVED_ID = "56TT9";
+
+  // same as the idprovider data, but with a partition for the empty release 11 so we can query it
+  static final TestDataRule.TestData TEST_DATA = new TestDataRule.TestData("idprovider", PROJECT_KEY,
+    Map.of("name_usage_archive", Map.of(
+      "dataset_key", PROJECT_KEY,
+      "n_id", "xyz"
+    )), Set.of(PROJECT_KEY, RELEASE_KEY), true);
+
+  @ClassRule
+  public static SqlSessionFactoryRule pgSetupRule = new PgSetupRule();
+
+  @Rule
+  public final TestDataRule testDataRule = new TestDataRule(TEST_DATA);
+
+  static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  TaxonDao dao() {
+    var factory = SqlSessionFactoryRule.getSqlSessionFactory();
+    var nDao = new NameDao(factory, NameUsageIndexService.passThru(), NameIndexFactory.passThru(), validator);
+    var mDao = new MetricsDao(factory);
+    return new TaxonDao(factory, nDao, mDao, new ThumborService(new ThumborConfig()),
+      NameUsageIndexService.passThru(), null, validator);
+  }
+
+  /**
+   * The /taxon/{id} endpoint - archived ids have always been reported here.
+   */
+  @Test
+  public void getOr404Archived() {
+    try {
+      dao().getOr404(DSID.of(RELEASE_KEY, ARCHIVED_ID));
+      fail("expected an ArchivedException for " + ARCHIVED_ID);
+    } catch (ArchivedException e) {
+      assertEquals(ARCHIVED_ID, e.usage.getId());
+      assertEquals((Integer) PROJECT_KEY, e.usage.getDatasetKey());
+    }
+  }
+
+  /**
+   * The /taxon/{id}/info endpoint the portal uses - used to throw a bare 404 without the archived usage.
+   */
+  @Test
+  public void getUsageInfoOr404Archived() {
+    try {
+      dao().getUsageInfoOr404(DSID.of(RELEASE_KEY, ARCHIVED_ID));
+      fail("expected an ArchivedException for " + ARCHIVED_ID);
+    } catch (ArchivedException e) {
+      assertEquals(ARCHIVED_ID, e.usage.getId());
+      assertEquals((Integer) PROJECT_KEY, e.usage.getDatasetKey());
+      assertNotNull("the tombstone needs the name to link to a successor", e.usage.getName());
+      assertNotNull(e.usage.getName().getScientificName());
+    }
+  }
+
+  /**
+   * An id that never existed stays a plain 404 in both endpoints.
+   */
+  @Test
+  public void unknownIdStays404() {
+    for (var key : Set.of(DSID.of(RELEASE_KEY, "notThere"), DSID.of(PROJECT_KEY, "notThere"))) {
+      try {
+        dao().getUsageInfoOr404(key);
+        fail("expected a NotFoundException for " + key);
+      } catch (ArchivedException e) {
+        fail("unexpected ArchivedException for " + key);
+      } catch (NotFoundException e) {
+        // expected
+      }
+    }
+  }
+}

--- a/dao/src/main/java/life/catalogue/dao/TaxonDao.java
+++ b/dao/src/main/java/life/catalogue/dao/TaxonDao.java
@@ -124,24 +124,48 @@ public class TaxonDao extends NameUsageBaseDao<Taxon, TaxonMapper> implements Ta
     try {
       return super.getOr404(key);
     } catch (NotFoundException e) {
+      throw enrich404(key, e);
+    }
+  }
+
+  /**
+   * Returns the full usage info for a taxon or synonym with the specified key or throws
+   * the same enriched exceptions as {@link #getOr404(DSID)}, so clients can redirect to
+   * the accepted usage or render a tombstone page for archived ids.
+   */
+  public UsageInfo getUsageInfoOr404(DSID<String> key) {
+    UsageInfo info = getUsageInfo(key);
+    if (info == null) {
+      throw enrich404(key, NotFoundException.notFound(Taxon.class, key));
+    }
+    return info;
+  }
+
+  /**
+   * Replaces a plain 404 with a more specific exception if we can explain where the id went:
+   *  - a SynonymException in case the id belongs to a synonym
+   *  - an ArchivedException in case the id existed in an earlier release and was archived
+   *
+   * @return the more specific exception to throw, or the given 404 if the id is unknown to us
+   */
+  private RuntimeException enrich404(DSID<String> key, NotFoundException notFound) {
+    try (SqlSession session = factory.openSession()) {
       // is it a synonym?
-      try (SqlSession session = factory.openSession()) {
-        SimpleName syn = session.getMapper(NameUsageMapper.class).getSimple(key);
-        if (syn != null) {
-          throw new SynonymException(key, syn.getParent());
-        }
-        // if it is a release, try if we have an archived version in the project
-        var info = DatasetInfoCache.CACHE.info(key.getDatasetKey());
-        if (info.origin.isRelease()) {
-          var projectKey = DSID.of(info.sourceKey, key.getId());
-          var anu= session.getMapper(ArchivedNameUsageMapper.class).get(projectKey);
-          if (anu != null) {
-            throw new ArchivedException(projectKey, anu);
-          }
-        }
-        // rethrow the original 404
-        throw e;
+      SimpleName syn = session.getMapper(NameUsageMapper.class).getSimple(key);
+      if (syn != null) {
+        return new SynonymException(key, syn.getParent());
       }
+      // if it is a release, try if we have an archived version in the project
+      var info = DatasetInfoCache.CACHE.info(key.getDatasetKey());
+      if (info.origin.isRelease()) {
+        var projectKey = DSID.of(info.sourceKey, key.getId());
+        var anu = session.getMapper(ArchivedNameUsageMapper.class).get(projectKey);
+        if (anu != null) {
+          return new ArchivedException(projectKey, anu);
+        }
+      }
+      // nothing better to say, keep the original 404
+      return notFound;
     }
   }
 

--- a/webservice/src/main/java/life/catalogue/resources/dataset/TaxonResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/dataset/TaxonResource.java
@@ -1,6 +1,5 @@
 package life.catalogue.resources.dataset;
 
-import life.catalogue.api.exception.NotFoundException;
 import life.catalogue.api.model.*;
 import life.catalogue.api.util.ObjectUtils;
 import life.catalogue.api.vocab.Language;
@@ -101,11 +100,7 @@ public class TaxonResource extends AbstractDatasetScopedResource<String, Taxon, 
   @Deprecated // use NameUsageResource instead
   @Path("{id}/info")
   public UsageInfo info(@PathParam("key") int datasetKey, @PathParam("id") String id) {
-    UsageInfo info = dao.getUsageInfo(DSID.of(datasetKey, id));
-    if (info == null) {
-      throw NotFoundException.notFound(Taxon.class, datasetKey, id);
-    }
-    return info;
+    return dao.getUsageInfoOr404(DSID.of(datasetKey, id));
   }
 
   @GET


### PR DESCRIPTION
GET /dataset/{key}/taxon/{id} reports ids that existed in an earlier release as an ArchivedException carrying the archived usage, but /taxon/{id}/info threw a bare 404. The portal renders taxon pages from /info, so removed ids showed a generic "not found" instead of a tombstone - see CatalogueOfLife/data#1644, where BOLD BIN ids that were reissued under their source id (GGJZT -> BOLD.AAK1046) lost their redirect.

Extract the 404 enrichment from TaxonDao.getOr404 into a shared helper and add getUsageInfoOr404 so both endpoints explain where an id went.