### PR TITLE
fix(hierarchy-sync): demote to an accepted taxon the project lacks

### DIFF
--- a/core/src/main/java/life/catalogue/assembly/HierarchySync.java
+++ b/core/src/main/java/life/catalogue/assembly/HierarchySync.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -82,11 +83,14 @@ import org.slf4j.LoggerFactory;
  *       topological sort over {@code parent_id} (rank ordinals are unreliable — UNRANKED / OTHER
  *       sit at the bottom regardless of tree position). Every inserted record is tagged with the
  *       sector's id and {@link Sector.Mode#HIERARCHY}, plus a source-dataset identifier so future
- *       runs can match by id. Finally each accepted matched project usage is rewired to its
- *       newly-imported immediate above-genus ancestor; synonyms are intentionally not rewired
- *       (their {@code parent_id} must keep pointing at an accepted taxon, not a higher-rank
- *       ancestor). Project usages lacking a source identifier are then re-matched against the
- *       source by name; full and higher-rank (HIGHERRANK) matches nest the usage under the
+ *       runs can match by id. When a match is a source synonym whose accepted taxon below genus has no
+ *       project equivalent, that accepted is imported too, so phase 2 can demote to it (backend#1582).
+ *       Finally each project usage accepted in both project and source is rewired to its closest
+ *       project ancestor; synonyms and usages about to be demoted are intentionally not rewired
+ *       (their {@code parent_id} must end up pointing at an accepted taxon, not a higher-rank
+ *       ancestor). Project usages lacking a source identifier are re-matched against the source by
+ *       name first. EXACT and VARIANT matches are treated like identifier matches and gain the source
+ *       identifier; the remaining full and higher-rank (HIGHERRANK) matches nest the usage under the
  *       resolved genus-or-higher anchor (importing it, or reusing an equivalent project node)
  *       and are flagged with {@code Issue.MATCHING_HIGHERRANK}; status, synonymy and authorship
  *       are left untouched for these.</li>
@@ -172,6 +176,12 @@ public class HierarchySync extends SectorRunnable {
   private Map<String, String> matchReverse = null;
   /** project usage id -> source anchor id (genus-or-higher) to nest a name-matched usage under. Placement-only. */
   private final Map<String, String> namePlacements = new LinkedHashMap<>();
+  /** name matched project usages promoted to a full match (in {@link #projectMatches}), which gain the source identifier. */
+  private final Set<String> nameMatched = new LinkedHashSet<>();
+  /** source id of an accepted taxon below genus that is missing in the project -> its source ancestor ids, nearest first. */
+  private final Map<String, List<String>> acceptedChains = new HashMap<>();
+  /** accepted project usages matched to a source synonym. Phase 2 demotes them, so phase 1 neither moves nor reuses them. */
+  private final Set<String> pendingDemotes = new HashSet<>();
 
   /** Lazily-filled cache for source dataset usages; constructed/closed around the four phases in {@link #doWork()}. */
   private UsageCache sourceCache;
@@ -321,8 +331,8 @@ public class HierarchySync extends SectorRunnable {
       LOG.info("Hierarchy sector {}: no project usages matched to source dataset {} - phase 1 has nothing to do", sectorKey, sourceDatasetKey);
       return;
     }
-    LOG.info("Hierarchy sector {}: matched {} usages by id, {} by name to source dataset {}",
-      sectorKey, projectMatches.size(), namePlacements.size(), sourceDatasetKey);
+    LOG.info("Hierarchy sector {}: matched {} usages by id, {} fully by name and placed {} by name in source dataset {}",
+      sectorKey, projectMatches.size() - nameMatched.size(), nameMatched.size(), namePlacements.size(), sourceDatasetKey);
     // Build matchReverse eagerly so phase 1 rewiring, dedup and phase 2 can resolve source ids through it.
     buildMatchReverse();
 
@@ -336,6 +346,7 @@ public class HierarchySync extends SectorRunnable {
 
     // Pass 4: rewire id-matched accepted usages to their closest project ancestor.
     rewireProjectParents(projectKey, sourceChainForAccepted);
+    identifyNameMatches(projectKey, sourceScope);
 
     // Pass 5: place name-matched usages under their anchor and flag them.
     placeNameMatches(projectKey);
@@ -365,8 +376,10 @@ public class HierarchySync extends SectorRunnable {
    *       — the usage falls through to the name match rather than being left unplaced for good.</li>
    *   <li><b>name-match fallback</b> — an accepted taxon <em>without</em> a usable source identifier whose
    *       name matches the source dataset (with higher-rank fallback), see {@link #nameMatchCandidate}.
-   *       EXACT/VARIANT/CANONICAL and HIGHERRANK matches yield a genus-or-higher source anchor recorded in
-   *       {@link #namePlacements} (placement only); ambiguous / no matches and synonyms are skipped.</li>
+   *       An unsnapped EXACT or VARIANT match of an unclaimed source usage is as good as an identifier match
+   *       and joins {@link #projectMatches}, recorded in {@link #nameMatched}. Other CANONICAL, HIGHERRANK and
+   *       snapped matches yield a genus-or-higher source anchor recorded in {@link #namePlacements} (placement
+   *       only); ambiguous / no matches and synonyms are skipped.</li>
    * </ul>
    *
    * The project is scanned exactly once. The scan also collects the whole project tree as
@@ -398,12 +411,16 @@ public class HierarchySync extends SectorRunnable {
         }
         projectUsages.put(u.getId(), new SimpleName(u));
         // 1) identifier match (only when a scope is configured); takes precedence over name matching
-        String tid = sourceScope == null ? null : findSourceIdByIdentifier(u, sourceScope);
-        if (tid != null && !sourceIdExists(tid)) {
-          // the source deleted or reissued this id. Trusting its mere presence would shadow the name match
-          // below for good and leave the usage unplaced, so treat the usage as unidentified instead.
-          staleIds++;
-          tid = null;
+        String tid = null;
+        if (sourceScope != null) {
+          // the first id that still resolves. A name match adds the current id next to a stale one, so a usage can carry both
+          List<String> ids = sourceIdsByIdentifier(u, sourceScope);
+          tid = ids.stream().filter(this::sourceIdExists).findFirst().orElse(null);
+          if (tid == null && !ids.isEmpty()) {
+            // the source deleted or reissued these ids. Trusting their mere presence would shadow the name match
+            // below for good and leave the usage unplaced, so treat the usage as unidentified instead.
+            staleIds++;
+          }
         }
         if (tid != null) {
           projectMatches.put(u.getId(), tid);
@@ -426,7 +443,9 @@ public class HierarchySync extends SectorRunnable {
         sectorKey, staleIds, sourceScope, sourceDatasetKey);
     }
 
-    // now that the project tree is in memory, name match the floating usages with their own classification
+    // now that the project tree is in memory, name match the floating usages with their own classification.
+    // A source usage that is already matched by id, or by an earlier name, is only good for placement.
+    final Set<String> claimed = new HashSet<>(projectMatches.values());
     try (SqlSession matchSession = factory.openSession(true);
          UsageMatcher sourceMatcher = sourceMatcherProvider.apply(sourceDatasetKey, matchSession)) {
       for (String usageId : floating) {
@@ -440,6 +459,15 @@ public class HierarchySync extends SectorRunnable {
         }
         // isMatch() is merely "a usage came back" and is true for AMBIGUOUS, so name the types we accept
         if (m == null || !m.isMatch() || !PLACEMENT_MATCH_TYPES.contains(m.type)) continue;
+        if (PROMOTE_MATCH_TYPES.contains(m.type) && !m.ignore && claimed.add(m.usage.getId())) {
+          // the very same name: as good as an identifier, so status, synonymy and authorship follow the source.
+          // That is what demotes a name the source has as a synonym, see backend#1582
+          projectMatches.put(usageId, m.usage.getId());
+          projectStatuses.put(usageId, sn.getStatus());
+          projectParents.put(usageId, sn.getParent());
+          nameMatched.add(usageId);
+          continue;
+        }
         String anchor = anchorFor(m);
         if (anchor == null) continue;
         namePlacements.put(usageId, anchor);
@@ -455,6 +483,15 @@ public class HierarchySync extends SectorRunnable {
    */
   private static final Set<MatchType> PLACEMENT_MATCH_TYPES =
     Set.of(MatchType.EXACT, MatchType.VARIANT, MatchType.CANONICAL, MatchType.HIGHERRANK);
+
+  /**
+   * Match types that make a name match as good as an identifier match, so it goes through status realignment,
+   * synonymy and authorship like one. {@link UsageMatcher} labels a surviving candidate EXACT or VARIANT from the live
+   * labels; a VARIANT typically differs by an authorship only one side carries, as clear author conflicts below genus
+   * are filtered out before. A snapped match ({@link UsageMatch#ignore}) is the matcher's best guess among several
+   * candidates and stays placement only.
+   */
+  private static final Set<MatchType> PROMOTE_MATCH_TYPES = Set.of(MatchType.EXACT, MatchType.VARIANT);
 
   /**
    * Is this project usage a floating name the name-match fallback may re-parent?
@@ -529,15 +566,16 @@ public class HierarchySync extends SectorRunnable {
     return cl;
   }
 
-  private static @Nullable String findSourceIdByIdentifier(NameUsageBase u, String sourceScope) {
-    List<Identifier> ids = u.getIdentifier();
-    if (ids == null) return null;
-    for (Identifier id : ids) {
-      if (sourceScope.equalsIgnoreCase(id.getScope())) {
-        return id.getId();
+  private static List<String> sourceIdsByIdentifier(NameUsageBase u, String sourceScope) {
+    List<String> result = new ArrayList<>();
+    if (u.getIdentifier() != null) {
+      for (Identifier id : u.getIdentifier()) {
+        if (sourceScope.equalsIgnoreCase(id.getScope())) {
+          result.add(id.getId());
+        }
       }
     }
-    return null;
+    return result;
   }
 
   /**
@@ -592,9 +630,19 @@ public class HierarchySync extends SectorRunnable {
           ancestors.putIfAbsent(t.getId(), t);
         }
       }
+      final boolean sourceSynonym = !chain.isEmpty() && chain.get(0).getStatus() != null && chain.get(0).getStatus().isSynonym();
+      if (sourceSynonym && chain.size() > 1) {
+        collectMissingAccepted(chain, ancestors);
+      }
       TaxonomicStatus ps = projectStatuses.get(e.getKey());
       if (ps != null && ps.isTaxon() && !chainIds.isEmpty()) {
-        sourceChainForAccepted.put(e.getKey(), chainIds);
+        if (sourceSynonym) {
+          // phase 2 demotes it to a synonym of the source's accepted. Moving the still accepted usage under that
+          // accepted's ancestors first put Gyraulus crista into the genus Armiger, see backend#1582
+          pendingDemotes.add(e.getKey());
+        } else {
+          sourceChainForAccepted.put(e.getKey(), chainIds);
+        }
       }
     }
 
@@ -623,6 +671,55 @@ public class HierarchySync extends SectorRunnable {
   }
 
   /**
+   * A matched source synonym whose accepted taxon has no project equivalent: collects that accepted to be imported,
+   * so phase 2 has something to demote the project usage to, and records its source ancestors to place it under.
+   * Accepted taxa of genus rank or higher are collected as ordinary ancestors already.
+   *
+   * @param chain the source classification of the matched synonym, starting with the synonym itself
+   */
+  private void collectMissingAccepted(List<SimpleNameCached> chain, Map<String, SimpleNameCached> ancestors) {
+    SimpleNameCached acc = chain.get(1);
+    if (acc.getStatus() == null || !acc.getStatus().isTaxon()) return;
+    Rank rank = acc.getRank();
+    if (rank == null || !rank.notOtherOrUnranked() || rank.higherOrEqualsTo(Rank.GENUS)) return;
+    if (matchReverse.containsKey(acc.getId())) return; // a project usage is matched to it, phase 2 resolves that one
+    ancestors.putIfAbsent(acc.getId(), acc);
+    acceptedChains.computeIfAbsent(acc.getId(), k -> chain.subList(2, chain.size()).stream().map(SimpleName::getId).toList());
+  }
+
+  /**
+   * Is an ancestor to be inserted still waiting for one of its parents? An imported accepted taxon below genus waits
+   * for every collected ancestor on its source chain, as its direct parent - a species or subgenus - is usually never
+   * collected at all.
+   */
+  private boolean awaitsParent(SimpleNameCached cached, Map<String, SimpleNameCached> remaining) {
+    List<String> chain = acceptedChains.get(cached.getId());
+    if (chain == null) {
+      return cached.getParent() != null && remaining.containsKey(cached.getParent());
+    }
+    return chain.stream().anyMatch(remaining::containsKey);
+  }
+
+  /**
+   * The project parent for an ancestor being inserted: the project copy of its source parent, or null to make it a
+   * project root. An imported accepted taxon below genus goes under the closest ancestor on its source chain the
+   * project holds.
+   */
+  private @Nullable String projectParentFor(SimpleNameCached cached) {
+    List<String> chain = acceptedChains.get(cached.getId());
+    if (chain == null) {
+      return cached.getParent() == null ? null : sourceToProject.get(cached.getParent());
+    }
+    for (String sourceId : chain) {
+      String pid = resolveProjectIdForSource(sourceId);
+      if (pid != null) {
+        return pid;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Resolves a source ancestor to an existing accepted project usage, so we can reuse it instead of
    * importing a duplicate. Resolution order:
    *   1. by identifier — the ancestor's source id is already a matched project usage ({@link #matchReverse});
@@ -643,10 +740,17 @@ public class HierarchySync extends SectorRunnable {
         return accepted;
       }
     }
-    // 2. by name
+    // 2. by name. Binomials below genus have homonyms across codes, so an imported accepted is matched with its
+    // source classification - the matcher only applies its taxonomic group filter to a query that has one
     UsageMatch m;
     try {
-      m = projectMatcher.parseAndMatch(new SimpleName(sourceAncestor), false);
+      if (acceptedChains.containsKey(sourceAncestor.getId())) {
+        List<SimpleNameCached> cl = sourceCache.getClassification(sourceAncestor.getId(), sourceLoader);
+        var snc = new SimpleNameClassified<>(new SimpleNameCached(new SimpleName(sourceAncestor)), cl.subList(1, cl.size()));
+        m = projectMatcher.parseAndMatch(snc, false);
+      } else {
+        m = projectMatcher.parseAndMatch(new SimpleName(sourceAncestor), false);
+      }
     } catch (NotFoundException e) {
       return null;
     }
@@ -687,8 +791,7 @@ public class HierarchySync extends SectorRunnable {
         // our required set (so we'll attach it as a project root), or parent has already been inserted
         List<SimpleNameCached> ready = new ArrayList<>();
         for (SimpleNameCached cached : remaining.values()) {
-          String pid = cached.getParent();
-          if (pid == null || !remaining.containsKey(pid)) {
+          if (!awaitsParent(cached, remaining)) {
             ready.add(cached);
           }
         }
@@ -700,13 +803,13 @@ public class HierarchySync extends SectorRunnable {
         }
         for (SimpleNameCached cached : ready) {
           final String origSourceId = cached.getId();
-          final String origSourceParentId = cached.getParent();
           // resolve project parent: if our parent is in the inserted set, use the new project id; otherwise null (root)
-          String projectParentId = origSourceParentId == null ? null : sourceToProject.get(origSourceParentId);
+          String projectParentId = projectParentFor(cached);
 
-          // project-side dedup: reuse an existing equivalent project node instead of importing a copy
+          // project-side dedup: reuse an existing equivalent project node instead of importing a copy.
+          // Never a usage phase 2 is about to demote - it would become a synonym of itself.
           String existing = findExistingProjectAncestor(cached, projectMatcher);
-          if (existing != null) {
+          if (existing != null && !pendingDemotes.contains(existing)) {
             sourceToProject.put(origSourceId, existing);
             remaining.remove(origSourceId);
             continue;
@@ -816,6 +919,25 @@ public class HierarchySync extends SectorRunnable {
   }
 
   /**
+   * Adds the source identifier to every name matched usage that was promoted to a full match, so the next run finds
+   * it by id. A usage demoted to a synonym would otherwise be lost: synonyms are never name matched, and the accepted
+   * it points at is deleted and imported anew. Placement-only matches gain no identifier.
+   */
+  private void identifyNameMatches(int projectKey, @Nullable String sourceScope) {
+    if (sourceScope == null || nameMatched.isEmpty()) return;
+    int written = 0;
+    try (SqlSession batch = factory.openSession(ExecutorType.BATCH, false)) {
+      NameUsageMapper num = batch.getMapper(NameUsageMapper.class);
+      for (String projectId : nameMatched) {
+        num.addIdentifier(DSID.of(projectKey, projectId), List.of(new Identifier(sourceScope, projectMatches.get(projectId))));
+        if (++written % 1000 == 0) batch.commit();
+      }
+      batch.commit();
+    }
+    LOG.info("Hierarchy sector {}: added a {} identifier to {} usages matched fully by name", sectorKey, sourceScope, written);
+  }
+
+  /**
    * Rewires each name-matched project usage under the project equivalent of its source anchor (imported
    * or deduped in phase 1) and flags it with {@link Issue#MATCHING_HIGHERRANK}. Placement only — status,
    * synonymy, authorship and identifiers are untouched. Skips updates that would be a no-op or create a
@@ -913,6 +1035,10 @@ public class HierarchySync extends SectorRunnable {
     }
     final int projectKey = sectorKey.getDatasetKey();
     int demoted = 0, promoted = 0, synonymRetargeted = 0, unchanged = 0, unresolved = 0, cycleBlocked = 0;
+    // source labels of the usages that could not be demoted or promoted, for the sync warnings
+    final List<String> undemoted = new ArrayList<>();
+    final List<String> unpromoted = new ArrayList<>();
+    final Set<String> promotedIds = new HashSet<>();
 
     try (SqlSession session = factory.openSession(true);
          SqlSession batch = factory.openSession(ExecutorType.BATCH, false)) {
@@ -920,99 +1046,125 @@ public class HierarchySync extends SectorRunnable {
       NameUsageMapper writeNum = batch.getMapper(NameUsageMapper.class);
       int written = 0;
 
-      for (Map.Entry<String, String> e : projectMatches.entrySet()) {
-        final String projectId = e.getKey();
-        final String sourceId = e.getValue();
-        TaxonomicStatus pStatus = projectStatuses.get(projectId);
-        SimpleNameCached source = sourceCache.getOrLoad(sourceId, sourceLoader);
-        if (source == null) {
-          // source gone? skip — phase 1 would have warned earlier, no point spamming again
-          continue;
-        }
-        TaxonomicStatus tStatus = source.getStatus();
-        if (pStatus == null || tStatus == null) {
-          unresolved++;
-          continue;
-        }
-
-        // both accepted -> already handled by phase 1 rewire
-        if (pStatus.isTaxon() && tStatus.isTaxon()) {
-          unchanged++;
-          continue;
-        }
-
-        // figure out the intended project parent given the source's parent
-        String newProjectParent = resolveProjectIdForSource(source.getParent());
-
-        if (pStatus.isTaxon() && tStatus.isSynonym()) {
-          // accepted -> synonym (demote)
-          if (newProjectParent == null) {
-            LOG.info("Hierarchy sector {}: cannot demote {} to synonym - source accepted parent {} not found in project", sectorKey, projectId, source.getParent());
-            unresolved++;
+      // promotions first: with an inverted synonymy the accepted a demotion needs may only exist as a project
+      // synonym that is about to be promoted, and the outcome must not depend on the order of the matches
+      for (boolean promotePass : new boolean[]{true, false}) {
+        for (Map.Entry<String, String> e : projectMatches.entrySet()) {
+          final String projectId = e.getKey();
+          final String sourceId = e.getValue();
+          if (promotedIds.contains(projectId)) {
             continue;
           }
-          if (wouldCreateCycle(projectKey, projectId, newProjectParent, readNum)) {
-            LOG.warn("Hierarchy sector {}: skipping demote of {} - new parent {} would create a cycle", sectorKey, projectId, newProjectParent);
-            cycleBlocked++;
+          TaxonomicStatus pStatus = projectStatuses.get(projectId);
+          SimpleNameCached source = sourceCache.getOrLoad(sourceId, sourceLoader);
+          if (source == null) {
+            // source gone? skip — phase 1 would have warned earlier, no point spamming again
             continue;
           }
-          writeNum.updateParentAndStatus(DSID.of(projectKey, projectId), newProjectParent, tStatus, user);
-          projectStatuses.put(projectId, tStatus);
-          projectParents.put(projectId, newProjectParent);
-          demoted++;
-          if (++written % 1000 == 0) batch.commit();
-          continue;
-        }
+          TaxonomicStatus tStatus = source.getStatus();
+          if (pStatus == null || tStatus == null) {
+            if (!promotePass) {
+              unresolved++;
+            }
+            continue;
+          }
+          if (promotePass != (pStatus.isSynonym() && tStatus.isTaxon())) {
+            continue;
+          }
 
-        if (pStatus.isSynonym() && tStatus.isTaxon()) {
-          // synonym -> accepted (promote)
-          if (newProjectParent == null) {
-            LOG.info("Hierarchy sector {}: cannot promote {} to accepted - source parent {} not found in project", sectorKey, projectId, source.getParent());
-            unresolved++;
+          // both accepted -> already handled by phase 1 rewire
+          if (pStatus.isTaxon() && tStatus.isTaxon()) {
+            unchanged++;
             continue;
           }
-          if (wouldCreateCycle(projectKey, projectId, newProjectParent, readNum)) {
-            LOG.warn("Hierarchy sector {}: skipping promote of {} - new parent {} would create a cycle", sectorKey, projectId, newProjectParent);
-            cycleBlocked++;
-            continue;
-          }
-          writeNum.updateParentAndStatus(DSID.of(projectKey, projectId), newProjectParent, tStatus, user);
-          projectStatuses.put(projectId, tStatus);
-          projectParents.put(projectId, newProjectParent);
-          promoted++;
-          if (++written % 1000 == 0) batch.commit();
-          continue;
-        }
 
-        // both synonym - retarget if the accepted differs, plus tweak status subtype if needed
-        if (pStatus.isSynonym() && tStatus.isSynonym()) {
-          if (newProjectParent != null) {
+          // figure out the intended project parent given the source's parent
+          String newProjectParent = resolveProjectIdForSource(source.getParent());
+
+          if (pStatus.isTaxon() && tStatus.isSynonym()) {
+            // accepted -> synonym (demote)
+            if (newProjectParent == null) {
+              LOG.warn("Hierarchy sector {}: cannot demote {} to synonym - source accepted parent {} not found in project", sectorKey, projectId, source.getParent());
+              undemoted.add(source.getLabel());
+              continue;
+            }
             if (wouldCreateCycle(projectKey, projectId, newProjectParent, readNum)) {
-              LOG.warn("Hierarchy sector {}: skipping synonym retarget of {} - new parent {} would create a cycle", sectorKey, projectId, newProjectParent);
+              LOG.warn("Hierarchy sector {}: skipping demote of {} - new parent {} would create a cycle", sectorKey, projectId, newProjectParent);
               cycleBlocked++;
               continue;
             }
-            // even if status subtype matches, retarget the parent to the project's accepted equivalent
             writeNum.updateParentAndStatus(DSID.of(projectKey, projectId), newProjectParent, tStatus, user);
             projectStatuses.put(projectId, tStatus);
             projectParents.put(projectId, newProjectParent);
-            synonymRetargeted++;
+            demoted++;
             if (++written % 1000 == 0) batch.commit();
-          } else if (pStatus != tStatus) {
-            // can't retarget but at least align the synonym subtype
-            writeNum.updateStatus(DSID.of(projectKey, projectId), tStatus, user);
+            continue;
+          }
+
+          if (pStatus.isSynonym() && tStatus.isTaxon()) {
+            // synonym -> accepted (promote)
+            if (newProjectParent == null) {
+              LOG.warn("Hierarchy sector {}: cannot promote {} to accepted - source parent {} not found in project", sectorKey, projectId, source.getParent());
+              unpromoted.add(source.getLabel());
+              continue;
+            }
+            if (wouldCreateCycle(projectKey, projectId, newProjectParent, readNum)) {
+              LOG.warn("Hierarchy sector {}: skipping promote of {} - new parent {} would create a cycle", sectorKey, projectId, newProjectParent);
+              cycleBlocked++;
+              continue;
+            }
+            writeNum.updateParentAndStatus(DSID.of(projectKey, projectId), newProjectParent, tStatus, user);
             projectStatuses.put(projectId, tStatus);
-            synonymRetargeted++;
+            projectParents.put(projectId, newProjectParent);
+            promotedIds.add(projectId);
+            promoted++;
             if (++written % 1000 == 0) batch.commit();
-          } else {
-            unchanged++;
+            continue;
+          }
+
+          // both synonym - retarget if the accepted differs, plus tweak status subtype if needed
+          if (pStatus.isSynonym() && tStatus.isSynonym()) {
+            if (newProjectParent != null) {
+              if (wouldCreateCycle(projectKey, projectId, newProjectParent, readNum)) {
+                LOG.warn("Hierarchy sector {}: skipping synonym retarget of {} - new parent {} would create a cycle", sectorKey, projectId, newProjectParent);
+                cycleBlocked++;
+                continue;
+              }
+              // even if status subtype matches, retarget the parent to the project's accepted equivalent
+              writeNum.updateParentAndStatus(DSID.of(projectKey, projectId), newProjectParent, tStatus, user);
+              projectStatuses.put(projectId, tStatus);
+              projectParents.put(projectId, newProjectParent);
+              synonymRetargeted++;
+              if (++written % 1000 == 0) batch.commit();
+            } else if (pStatus != tStatus) {
+              // can't retarget but at least align the synonym subtype
+              writeNum.updateStatus(DSID.of(projectKey, projectId), tStatus, user);
+              projectStatuses.put(projectId, tStatus);
+              synonymRetargeted++;
+              if (++written % 1000 == 0) batch.commit();
+            } else {
+              unchanged++;
+            }
           }
         }
       }
       batch.commit();
     }
-    LOG.info("Hierarchy sector {}: phase 2 done - demoted={}, promoted={}, synonyms retargeted/realigned={}, unchanged={}, unresolved={}, cycle-blocked={}",
-      sectorKey, demoted, promoted, synonymRetargeted, unchanged, unresolved, cycleBlocked);
+    warnUnresolved("demoted to a synonym", undemoted);
+    warnUnresolved("promoted to accepted", unpromoted);
+    LOG.info("Hierarchy sector {}: phase 2 done - demoted={}, promoted={}, synonyms retargeted/realigned={}, unchanged={}, unresolved={}, " +
+        "not demoted={}, not promoted={}, cycle-blocked={}",
+      sectorKey, demoted, promoted, synonymRetargeted, unchanged, unresolved, undemoted.size(), unpromoted.size(), cycleBlocked);
+  }
+
+  /**
+   * Adds a single warning to the sync for all usages phase 2 could not realign, with a few example names.
+   */
+  private void warnUnresolved(String action, List<String> sourceLabels) {
+    if (!sourceLabels.isEmpty()) {
+      state.addWarning(String.format("%d usages could not be %s, as their parent in source dataset %d has no equivalent in the project, e.g. %s",
+        sourceLabels.size(), action, sourceDatasetKey, String.join("; ", sourceLabels.subList(0, Math.min(5, sourceLabels.size())))));
+    }
   }
 
   /**

--- a/core/src/test/java/life/catalogue/assembly/HierarchySyncIT.java
+++ b/core/src/test/java/life/catalogue/assembly/HierarchySyncIT.java
@@ -205,7 +205,8 @@ public class HierarchySyncIT {
    * to the target: A is accepted with B as its synonym in the project, but the target has B
    * accepted with A as its synonym. Phase 2 must not produce the 2-cycle A ↔ B (which the old
    * code did, because it happily resolved a target accepted id to the project synonym that
-   * carried that id and used the synonym as a parent_id).
+   * carried that id and used the synonym as a parent_id). Since promotions run before demotions
+   * the pair ends up exactly as in the target.
    */
   @Test
   public void invertedSynonymyDoesNotCreateCycle() throws Exception {
@@ -231,14 +232,11 @@ public class HierarchySyncIT {
     assertNotNull(a);
     assertNotNull(b);
 
-    // The cycle guard must have blocked the demote of A — leaving A accepted with its original
-    // (non-B) parent. The only forbidden outcome is A.parent_id == B, which would close the loop.
-    assertNotEquals("P_A.parent_id must not equal P_B (would close a parent cycle)", P_B, a.getParentId());
-
-    // No project-side cycle anywhere in this pair.
-    if (P_A.equals(b.getParentId())) {
-      assertNotEquals("If P_B still points at P_A, then P_A must not point back at P_B", P_B, a.getParentId());
-    }
+    // Promotions run before demotions: B leaves A first, so A can then become B's synonym without closing a loop.
+    assertTrue("B is accepted in the target and must have been promoted", b.getStatus().isTaxon());
+    assertNotEquals("P_B must no longer point at P_A", P_A, b.getParentId());
+    assertTrue("A is a synonym in the target and must have been demoted", a.getStatus().isSynonym());
+    assertEquals("A must have become a synonym of B", P_B, a.getParentId());
   }
 
   /**
@@ -529,8 +527,9 @@ public class HierarchySyncIT {
   }
 
   /**
-   * Name-match fallback, full match: a species that exists in the source but was never id-matched is
-   * placed under its genus (imported) without becoming an identifier match (no status/synonym change).
+   * Full name match: a species that exists in the source but was never id-matched is placed under its genus
+   * (imported) and treated like an identifier match - it gains the source identifier and is no higher rank
+   * placement. See backend#1582.
    */
   @Test
   public void nameMatchFullMatchPlacesUnderGenus() throws Exception {
@@ -556,8 +555,9 @@ public class HierarchySyncIT {
     assertNotNull("genus Agrostemma should have been imported", genus);
     NameUsageBase floating = getByID(PROJECT_KEY, P_floating);
     assertEquals("floating species should nest under its genus", genus.getId(), floating.getParentId());
-    assertNull("placed species must not gain an identifier", floating.getIdentifier());
-    assertHasVerbatimIssue(PROJECT_KEY, P_floating, Issue.MATCHING_HIGHERRANK);
+    assertHasIdentifier(floating, SCOPE, T_Ag_githago);
+    assertEquals("a full match is no higher rank placement", 0,
+      verbatimIssueCount(PROJECT_KEY, P_floating, Issue.MATCHING_HIGHERRANK));
   }
 
   /**
@@ -764,7 +764,11 @@ public class HierarchySyncIT {
     assertNotNull("genus should have been imported for the name match", genus);
     NameUsageBase floating = getByID(PROJECT_KEY, P_floating);
     assertEquals("a usage with a stale identifier must be placed by name instead", genus.getId(), floating.getParentId());
-    assertHasVerbatimIssue(PROJECT_KEY, P_floating, Issue.MATCHING_HIGHERRANK);
+    assertHasIdentifier(floating, SCOPE, T_Stalesp);
+
+    // the next run follows the identifier that still resolves and adds no further one
+    runHierarchySync();
+    assertEquals(2, getByID(PROJECT_KEY, P_floating).getIdentifier().size());
   }
 
   /**
@@ -803,7 +807,232 @@ public class HierarchySyncIT {
     assertNull("no part of the botanical lineage may be imported", getByName(PROJECT_KEY, Rank.FAMILY, "Lamiaceae"));
   }
 
+  // ---------- a synonym of an accepted taxon the project lacks, backend#1582 ----------
+
+  static final String T_Planorbidae = "T_Planorbidae";
+  static final String T_Armiger = "T_Armiger";
+  static final String T_Arm_crista = "T_Arm_crista";
+  static final String T_Gyr_crista = "T_Gyr_crista";
+  static final String P_Gyr_crista = "p_Gyr_crista";
+
+  /**
+   * The project name carries the id of a source synonym whose accepted taxon the project does not hold.
+   * The accepted has to be imported and the project name demoted to its synonym. It used to stay accepted
+   * and was moved under the accepted's genus instead: Gyraulus crista under Armiger in the Archis project.
+   * https://github.com/CatalogueOfLife/backend/issues/1582
+   */
+  @Test
+  public void idMatchedSynonymOfMissingAcceptedIsDemoted() throws Exception {
+    populateArmigerCrista(null);
+    insertTaxonWithIdentifier(PROJECT_KEY, P_Gyr_crista, null, Rank.SPECIES, "Gyraulus crista", T_Gyr_crista);
+
+    runHierarchySync();
+
+    assertDemotedToImportedArmigerCrista();
+  }
+
+  /**
+   * A re-run deletes the imported accepted the demoted synonym points at. The synonym is then a project
+   * synonym of a source synonym and has to be retargeted to the re-imported accepted.
+   */
+  @Test
+  public void demotionToImportedAcceptedSurvivesRerun() throws Exception {
+    populateArmigerCrista(null);
+    insertTaxonWithIdentifier(PROJECT_KEY, P_Gyr_crista, null, Rank.SPECIES, "Gyraulus crista", T_Gyr_crista);
+
+    runHierarchySync();
+    int taxa = countDataset(PROJECT_KEY, false);
+    int synonyms = countDataset(PROJECT_KEY, true);
+
+    runHierarchySync();
+
+    assertEquals("a second sync must not duplicate accepted taxa", taxa, countDataset(PROJECT_KEY, false));
+    assertEquals("a second sync must not duplicate synonyms", synonyms, countDataset(PROJECT_KEY, true));
+    assertDemotedToImportedArmigerCrista();
+  }
+
+  /**
+   * A full name match is as good as an identifier: without one the name is demoted all the same, and it
+   * gains the source identifier so the next run can find the synonym it became.
+   */
+  @Test
+  public void exactNameMatchSynonymOfMissingAcceptedIsDemoted() throws Exception {
+    populateArmigerCrista(null);
+    insertTaxon(PROJECT_KEY, P_Gyr_crista, null, Rank.SPECIES, "Gyraulus crista");
+    rematchNames();
+
+    runHierarchySync();
+
+    assertDemotedToImportedArmigerCrista();
+    assertHasIdentifier(getByID(PROJECT_KEY, P_Gyr_crista), SCOPE, T_Gyr_crista);
+    assertEquals("a full match is no higher rank placement", 0,
+      verbatimIssueCount(PROJECT_KEY, P_Gyr_crista, Issue.MATCHING_HIGHERRANK));
+  }
+
+  /**
+   * The source synonym carries an authorship the project name lacks - the shape of the Archis text tree names.
+   */
+  @Test
+  public void variantNameMatchSynonymOfMissingAcceptedIsDemoted() throws Exception {
+    populateArmigerCrista(auth("Linnaeus", "1758"));
+    insertTaxon(PROJECT_KEY, P_Gyr_crista, null, Rank.SPECIES, "Gyraulus crista");
+    rematchNames();
+
+    runHierarchySync();
+
+    assertDemotedToImportedArmigerCrista();
+    assertHasIdentifier(getByID(PROJECT_KEY, P_Gyr_crista), SCOPE, T_Gyr_crista);
+  }
+
+  /**
+   * Once demoted a name-matched usage is a synonym and never name matched again, so only the identifier it
+   * gained keeps it attached to the accepted that the re-run imports anew.
+   */
+  @Test
+  public void nameMatchedDemotionSurvivesRerun() throws Exception {
+    populateArmigerCrista(null);
+    insertTaxon(PROJECT_KEY, P_Gyr_crista, null, Rank.SPECIES, "Gyraulus crista");
+    rematchNames();
+
+    runHierarchySync();
+    runHierarchySync();
+
+    assertDemotedToImportedArmigerCrista();
+    assertEquals("a re-run must not add the identifier again", 1, getByID(PROJECT_KEY, P_Gyr_crista).getIdentifier().size());
+  }
+
+  /**
+   * The accepted exists in the project already, without any identifier. It is reused, not imported again.
+   */
+  @Test
+  public void demotesToExistingProjectAccepted() throws Exception {
+    final String P_Armiger = "p_Armiger";
+    final String P_Arm_crista = "p_Arm_crista";
+    populateArmigerCrista(null);
+    insertTaxon(PROJECT_KEY, P_Armiger, null, Rank.GENUS, "Armiger");
+    insertTaxon(PROJECT_KEY, P_Arm_crista, P_Armiger, Rank.SPECIES, "Armiger crista");
+    insertTaxonWithIdentifier(PROJECT_KEY, P_Gyr_crista, null, Rank.SPECIES, "Gyraulus crista", T_Gyr_crista);
+    rematchNames();
+
+    runHierarchySync();
+
+    NameUsageBase accepted = getByName(PROJECT_KEY, Rank.SPECIES, "Armiger crista");
+    assertEquals("the existing project Armiger crista must be reused", P_Arm_crista, accepted.getId());
+    assertNull(accepted.getSectorKey());
+    NameUsageBase gyr = getByID(PROJECT_KEY, P_Gyr_crista);
+    assertTrue(gyr.getStatus().isSynonym());
+    assertEquals(P_Arm_crista, gyr.getParentId());
+  }
+
+  /**
+   * An infraspecific accepted whose species the project does not hold goes under the genus. Its direct source
+   * parent is never imported, so insertion order and parent have to follow the source chain.
+   */
+  @Test
+  public void importedInfraspecificAcceptedNestsUnderGenus() throws Exception {
+    final String T_Arm_crista_cristata = "T_Arm_crista_cristata";
+    final String T_Gyr_crista_cristata = "T_Gyr_crista_cristata";
+    final String P_Gyr_crista_cristata = "p_Gyr_crista_cristata";
+    populateArmigerCrista(null);
+    insertTaxon(targetKey, T_Arm_crista_cristata, T_Arm_crista, Rank.SUBSPECIES, "Armiger crista cristata");
+    insertSynonym(targetKey, T_Gyr_crista_cristata, T_Arm_crista_cristata, Rank.SUBSPECIES, "Gyraulus crista cristata");
+    insertTaxonWithIdentifier(PROJECT_KEY, P_Gyr_crista_cristata, null, Rank.SUBSPECIES, "Gyraulus crista cristata", T_Gyr_crista_cristata);
+
+    runHierarchySync();
+
+    NameUsageBase armiger = getByName(PROJECT_KEY, Rank.GENUS, "Armiger");
+    assertNotNull(armiger);
+    NameUsageBase accepted = getByName(PROJECT_KEY, Rank.SUBSPECIES, "Armiger crista cristata");
+    assertNotNull("the missing infraspecific accepted should have been imported", accepted);
+    assertEquals("it nests under the genus, as its species is not in the project", armiger.getId(), accepted.getParentId());
+    assertNull("the species is not imported", getByName(PROJECT_KEY, Rank.SPECIES, "Armiger crista"));
+    NameUsageBase gyr = getByID(PROJECT_KEY, P_Gyr_crista_cristata);
+    assertTrue(gyr.getStatus().isSynonym());
+    assertEquals(accepted.getId(), gyr.getParentId());
+  }
+
+  /**
+   * Guard for the promotion of name matches: an authorship conflict removes the species candidate, so the
+   * usage falls back to a higher rank placement and keeps its status.
+   */
+  @Test
+  public void authorshipConflictStaysPlacementOnly() throws Exception {
+    populateArmigerCrista(auth("Linnaeus", "1758"));
+    insertTaxon(targetKey, "T_Gyraulus", T_Planorbidae, Rank.GENUS, "Gyraulus");
+    insertTaxonWithAuthorship(PROJECT_KEY, P_Gyr_crista, null, Rank.SPECIES, "Gyraulus crista", auth("Smith", "1900"), null);
+    rematchNames();
+
+    runHierarchySync();
+
+    NameUsageBase gyraulus = getByName(PROJECT_KEY, Rank.GENUS, "Gyraulus");
+    assertNotNull("the genus should have been imported for the higher rank match", gyraulus);
+    NameUsageBase gyr = getByID(PROJECT_KEY, P_Gyr_crista);
+    assertTrue("a higher rank placement must not change the status", gyr.getStatus().isTaxon());
+    assertEquals(gyraulus.getId(), gyr.getParentId());
+    assertNull("a higher rank placement must not gain an identifier", gyr.getIdentifier());
+    assertHasVerbatimIssue(PROJECT_KEY, P_Gyr_crista, Issue.MATCHING_HIGHERRANK);
+    assertNull("nothing may be imported for the conflicting species", getByName(PROJECT_KEY, Rank.SPECIES, "Armiger crista"));
+  }
+
+  /**
+   * Source: Animalia > Planorbidae > Armiger > Armiger crista, with Gyraulus crista as its synonym.
+   * An authorship on the synonym makes an authorless project name a VARIANT rather than an EXACT match.
+   */
+  private static void populateArmigerCrista(Authorship synonymAuthorship) {
+    insertTaxon(targetKey, T_Planorbidae, T_Animalia, Rank.FAMILY, "Planorbidae");
+    insertTaxon(targetKey, T_Armiger, T_Planorbidae, Rank.GENUS, "Armiger");
+    insertTaxon(targetKey, T_Arm_crista, T_Armiger, Rank.SPECIES, "Armiger crista");
+    insertSynonymWithAuthorship(targetKey, T_Gyr_crista, T_Arm_crista, Rank.SPECIES, "Gyraulus crista", synonymAuthorship);
+  }
+
+  private void assertDemotedToImportedArmigerCrista() {
+    NameUsageBase armiger = getByName(PROJECT_KEY, Rank.GENUS, "Armiger");
+    assertNotNull("genus Armiger should have been imported", armiger);
+    NameUsageBase accepted = getByName(PROJECT_KEY, Rank.SPECIES, "Armiger crista");
+    assertNotNull("the missing accepted Armiger crista should have been imported", accepted);
+    assertTrue(accepted.getStatus().isTaxon());
+    assertEquals(hierarchySector.getId(), accepted.getSectorKey());
+    assertEquals("the imported accepted should nest under its genus", armiger.getId(), accepted.getParentId());
+    assertHasIdentifier(accepted, SCOPE, T_Arm_crista);
+    assertVerbatimSource(accepted, targetKey, T_Arm_crista);
+
+    NameUsageBase gyr = getByID(PROJECT_KEY, P_Gyr_crista);
+    assertTrue("Gyraulus crista should have been demoted to a synonym", gyr.getStatus().isSynonym());
+    assertEquals("Gyraulus crista should be a synonym of the imported Armiger crista", accepted.getId(), gyr.getParentId());
+    assertEquals("the demoted name must not be copied in again as a synonym", 1,
+      listByName(PROJECT_KEY, Rank.SPECIES, "Gyraulus crista").size());
+  }
+
+  /** Names must be matched to the names index for the postgres matcher to find candidates. */
+  private void rematchNames() {
+    // reset the shared in-memory nidx so stale IDs from prior tests do not cause FK violations
+    NameMatchingRule.getIndex().reset();
+    matchingRule.rematch(targetKey);
+    matchingRule.rematch(PROJECT_KEY);
+  }
+
   // ---------- helpers ----------
+
+  private static void insertSynonymWithAuthorship(int datasetKey, String id, String acceptedId, Rank rank, String scientificName,
+                                                  Authorship combinationAuthorship) {
+    try (SqlSession s = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {
+      Name n = buildName(datasetKey, id, scientificName, rank);
+      if (combinationAuthorship != null) {
+        n.setCombinationAuthorship(combinationAuthorship);
+        n.rebuildAuthorship();
+      }
+      s.getMapper(NameMapper.class).create(n);
+      Synonym syn = new Synonym();
+      syn.setDatasetKey(datasetKey);
+      syn.setId(id);
+      syn.setName(n);
+      syn.setStatus(TaxonomicStatus.SYNONYM);
+      syn.setParentId(acceptedId);
+      syn.setOrigin(life.catalogue.api.vocab.Origin.SOURCE);
+      syn.applyUser(USER);
+      s.getMapper(SynonymMapper.class).create(syn);
+    }
+  }
 
   private static Sector createAttachSectorWithTarget(NameUsageBase target) {
     try (SqlSession s = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {

--- a/docs/2026-09-11-hierarchy-sync-demote-to-missing-accepted.md
+++ b/docs/2026-09-11-hierarchy-sync-demote-to-missing-accepted.md
@@ -1,0 +1,90 @@
+# Hierarchy sync: demote to an accepted taxon the project lacks
+
+Date: 2026-09-11
+Status: implemented on branch `feat/hierarchy-demote-missing-accepted`, not yet released
+Issue: [backend#1582](https://github.com/CatalogueOfLife/backend/issues/1582)
+
+## Problem
+
+The Archis project (316318) delegates its higher classification to the latest COL XRelease through a
+hierarchy sector. Its names come from two text tree datasets that carry COL identifiers added on import
+(`add identifiers from: 3LXR`). Two names from the issue, checked against COL26.8 XR (316165):
+
+| project usage | identifier | that id in COL | accepted in COL | in the project? |
+|---|---|---|---|---|
+| *Gyraulus crista* | `col:3HYBL` | *Gyraulus (Armiger) crista*, synonym | *Armiger crista* | no |
+| *Hieracium pilosella* | `col:3LS95` | *Hieracium pilosella* L., synonym | *Pilosella officinarum* | no |
+
+Both stayed accepted, and *Gyraulus crista* was moved under the genus *Armiger*:
+
+1. Phase 1 collected the synonym's source chain and rewired the still accepted project usage under the
+   closest ancestor the project held - the imported genus of the accepted species.
+2. Phase 2 wanted to demote it, but the source's accepted taxon had no project equivalent. It logged
+   "cannot demote" at INFO and left the usage accepted.
+
+A demote only ever worked when the project happened to hold the accepted taxon already. Full name matches
+could not demote at all: the 2026-06-26 name match fallback deliberately used them for placement only.
+
+## Goal
+
+- Import the source's accepted taxon (below genus) when the project lacks it, tagged with the hierarchy
+  sector like every imported ancestor, and demote the project usage to its synonym.
+- Treat full name matches (EXACT, VARIANT) like identifier matches: status, synonymy and authorship follow
+  the source, and the usage gains the source identifier.
+
+## Non-goals
+
+- Dangling references after a re-sync. `deleteOld` removes the imported accepted every run and re-imports it
+  under a new id. A demoted synonym is re-pointed on the next run because it is matched again - by the
+  identifier it carries - but anything no longer matched keeps a dangling parent. Stable ids and a repair step
+  are a separate change.
+- Placement-only matches (CANONICAL, HIGHERRANK, snapped and ambiguous) keep their current behaviour.
+- Synonyms are still not name matched.
+
+## Design
+
+- **Missing accepted.** `collectAncestors` sees a matched source synonym whose accepted taxon is ranked below
+  genus and not matched by any project usage. It adds the accepted to the ancestors to import and records its
+  source ancestor chain. `insertAncestorsTopDown` waits for any pending ancestor on that chain, because the
+  direct source parent (a species or subgenus) is usually never collected. It places the import under the
+  closest ancestor the project holds, and dedups it against an existing accepted project usage of that name and
+  rank. That also happens on a re-run, where the demoted usage is a project synonym of a source synonym whose
+  accepted was just deleted.
+- **No premature rewire.** An accepted project usage matched to a source synonym is not rewired in phase 1 any
+  more. Phase 2 demotes it; if it cannot, the usage stays where it was instead of landing in a foreign genus.
+- **Promoted name matches.** An EXACT or VARIANT match that is not snapped and whose source usage no identifier
+  match or earlier name match claimed joins `projectMatches`. A new pass adds the source identifier. Without
+  it a demoted usage would be lost on the next run: it is a synonym and never name matched again. These usages
+  are no longer flagged `MATCHING_HIGHERRANK`, which describes a higher rank placement.
+- **Stale identifiers.** A usage may now carry a stale id next to the current one, so identifier discovery uses
+  the first id that still resolves.
+- **Phase 2 order.** Promotions run before demotions. With inverted synonymy the accepted a demotion needs
+  exists only as a project synonym awaiting promotion, and the outcome used to depend on map order.
+  Unresolvable demotions and promotions are logged at WARN and summarised as a sector sync warning.
+
+## Rejected alternatives
+
+- **Only flag an unresolvable demote.** The project would never converge on the source; every re-sync would
+  report the same names.
+- **Keep full name matches placement only.** The Archis names happen to carry identifiers, but names without
+  one would stay accepted wherever the source has them as synonyms.
+- **Promote name matches without adding the identifier.** Breaks on the second run, see above.
+- **Also promote CANONICAL matches, or snaps.** A canonical match ignores authorship, and a snap is the matcher
+  picking one of several candidates. A demotion based on either can move a homonym.
+- **Relink children around `deleteOld` now.** Deferred to the stable id change.
+
+## Outcome
+
+- `HierarchySyncIT` covers the two identifier and name match shapes of the issue, their re-runs, reuse of an
+  accepted the project already holds, an infraspecific accepted whose species is missing, and a guard that an
+  authorship conflict still ends in a higher rank placement.
+- Two existing tests changed their expectations on purpose:
+  - `nameMatchFullMatchPlacesUnderGenus` and `nameMatchRescuesStaleIdentifier`: a full match now gains the source
+    identifier and is not flagged `MATCHING_HIGHERRANK`.
+  - `invertedSynonymyDoesNotCreateCycle`: with promotions first the pair now ends up exactly as in the source
+    (B accepted, A its synonym). It used to only assert that no cycle formed, which order dependent code could
+    reach by leaving both unchanged.
+- The Archis identifiers point at COL synonyms (checked for both names of the issue on 2026-09-11), so the real
+  cases take the identifier path; the name match promotion is for names without one.
+- Not done here: stable ids for re-imported rows and a repair of dangling parents after a sync and before a
+  release, including `ProjectRelease`, which aborts in `IdProvider` on a missing parent today.

--- a/docs/HIERARCHY-SYNC.md
+++ b/docs/HIERARCHY-SYNC.md
@@ -38,7 +38,8 @@ living on the project. The sector carries:
 | `mode = HIERARCHY` | distinguishes from ATTACH / UNION / MERGE |
 | `id` | the sectorKey tagged on every record produced by the sync |
 
-Records produced by the sync (imported above-genus taxa + their copied synonyms) carry that
+Records produced by the sync (imported taxa of genus rank or higher, accepted taxa below genus imported
+so a project name can be demoted to them, and the synonyms copied for all of these) carry that
 `sector_key` and `sector_mode = HIERARCHY`, so a previous run is wiped through the standard
 `SectorProcessable.MAPPERS` deletion path before a new one starts. Project usages that were merely
 *rewired* (parent_id or status updated) are not tagged — that keeps user data outside the sector's
@@ -93,9 +94,9 @@ Implemented as four passes inside `syncHigherClassification()`:
 #### 2a. `discoverMatches`
 
 Streams every project usage via `NameUsageMapper.processDataset(projectKey, null, null)`. For each
-usage, scans `NameUsageBase.identifier` for an entry whose scope (resolved via
-`IdentifierScopeResolver.resolve(sourceDatasetKey)`) matches the target. Matches populate two
-in-memory maps used by phases 2 and 3:
+usage, scans `NameUsageBase.identifier` for entries whose scope (resolved via
+`IdentifierScopeResolver.resolve(sourceDatasetKey)`) matches the target and takes the first id that
+still resolves in the source. Matches populate the in-memory maps used by phases 2 to 4:
 
 - `projectMatches: projectId → targetId`
 - `projectStatuses: projectId → TaxonomicStatus`
@@ -104,14 +105,28 @@ Usages already tagged with this sector's key are skipped defensively.
 
 > Identifiers on `Name` are intentionally **not** consulted — only `NameUsageBase.identifier`.
 
+Accepted usages without a usable identifier are then matched by name (see
+[What the name-match fallback refuses to do](#what-the-name-match-fallback-refuses-to-do)). An
+`EXACT` or `VARIANT` match that the matcher did not snap, to a source usage no other project usage
+claimed, is **as good as an identifier**: it joins `projectMatches` and therefore goes through phases
+2 to 4, and phase 1 adds the source identifier to the usage once the rewiring is done. Without that
+identifier a usage demoted to a synonym would be lost on the next run, as synonyms are never name
+matched. All other accepted name matches are used for placement only.
+
 #### 2b. `collectAncestors`
 
-For each match calls `TaxonMapper.classification(DSID(sourceDatasetKey, targetId))`. The recursive
-CTE returns the parent chain ordered immediate-parent-up-to-root, excluding the start node.
-Ancestors with rank strictly higher than `GENUS` (`Rank.higherThan(GENUS)`) are unioned into a
-single `Map<targetId, Taxon>`. The first such ancestor becomes the project usage's
-**immediate above-genus ancestor** — but only recorded for **accepted** project usages; synonyms
-must keep `parent_id` pointing at an accepted taxon, not at a higher-rank ancestor.
+For each match walks the source classification from the lazily filled `UsageCache` - the matched usage
+first, then its parents up to the root. Ancestors of rank `GENUS` or higher are unioned into a single
+map to import. The chain is recorded for rewiring only for usages that are accepted **both** in the
+project and the source; a project usage the source has as a synonym is left to phase 2, which demotes
+it. Moving it under the ancestors of its source accepted first is what put *Gyraulus crista* into the
+genus *Armiger* ([backend#1582](https://github.com/CatalogueOfLife/backend/issues/1582)).
+
+When the matched source usage is a synonym whose accepted taxon is ranked below genus and matched by no
+project usage, that **accepted taxon is imported as well**, together with its source ancestor chain.
+This applies to a project usage that is accepted (to be demoted) as much as to one that is a synonym
+already - which is what a demoted usage is on the next run, after `deleteOld` removed the accepted it
+pointed at.
 
 #### 2c. `insertAncestorsTopDown`
 
@@ -137,11 +152,18 @@ For each insertion:
 The map `targetToProject: targetAncestorId → newProjectId` is built as a side effect and shared
 with phases 2 and 3.
 
+An imported accepted taxon below genus waits until no ancestor on its source chain is pending, as its
+direct source parent (a species or subgenus) is usually never collected. It is placed under the
+closest ancestor on that chain the project holds. Before importing anything the sync looks for an
+equivalent accepted project usage (by identifier, then by name and rank) and reuses it; a project usage
+that phase 2 is about to demote is never reused as its own accepted.
+
 #### 2d. `rewireProjectParents`
 
-Calls `NameUsageMapper.updateParentId(...)` for every **accepted** matched project usage,
-re-anchoring it under its newly-imported immediate above-genus ancestor. Synonyms are not rewired
-in this pass; phase 2 handles them.
+Calls `NameUsageMapper.updateParentId(...)` for every matched project usage that is accepted in the
+project and the source, re-anchoring it under the closest ancestor the project now holds. Synonyms and
+usages the source has as synonyms are not rewired in this pass; phase 2 handles them. Afterwards
+promoted name matches receive the source identifier.
 
 Each move is checked with `wouldCreateCycle(...)` first, the same guard phases 2 and 5 use. Two
 usages of this pass can otherwise be rewired onto each other — each move legal on its own, together
@@ -150,8 +172,9 @@ are logged and counted as `cycle-blocked`.
 
 ### 3. Phase 2 — Status realignment
 
-`realignStatus()` iterates `projectMatches` and, for each pair, loads the target usage to compare
-statuses. Decisions:
+`realignStatus()` iterates `projectMatches` twice, promotions first, and for each pair loads the
+target usage to compare statuses. Promoting first matters for inverted synonymy: the accepted a
+demotion needs may only exist as a project synonym that is about to be promoted. Decisions:
 
 | project | target | action |
 |---|---|---|
@@ -160,10 +183,11 @@ statuses. Decisions:
 | synonym | accepted | promote — `updateParentAndStatus(projectId, projectEquivOf(target.parentId), target.status)` |
 | synonym | synonym | retarget the synonym's accepted parent (and align subtype if it differs) |
 
-`projectEquivOf(targetId)` first checks `targetToProject` (newly imported ancestors) and falls back
-to a lazily-built reverse of `projectMatches`. If neither resolves, the project usage is left
-untouched and counted as `unresolved` in the run summary — we'd rather skip a record than orphan
-it.
+`projectEquivOf(targetId)` first checks `targetToProject` (newly imported ancestors, including
+accepted taxa below genus imported for exactly this purpose) and falls back to a lazily-built reverse
+of `projectMatches`. If neither resolves, the project usage is left untouched - we'd rather skip a
+record than orphan it. Such demotions and promotions are logged at WARN, counted separately, and
+summarised with a few example names as a warning of the sector sync.
 
 Each successful update writes back into the in-memory `projectStatuses` so phase 3 can read the
 post-realignment status without a re-query.
@@ -172,10 +196,10 @@ post-realignment status without a re-query.
 
 `copySynonymies()` builds the universe of accepted (project, target) pairs:
 
-- every entry of `targetToProject` (above-genus ancestors imported in phase 1 — accepted by
-  construction), plus
+- every entry of `targetToProject` (ancestors of genus rank or higher, and accepted taxa below genus
+  imported for a demotion, all accepted by construction), plus
 - every matched project usage whose effective `projectStatuses` value is `isTaxon()` (originally
-  accepted, or promoted by phase 2).
+  accepted, or promoted by phase 2). That includes full name matches.
 
 For each accepted pair, `SynonymMapper.listByTaxon(DSID(sourceDatasetKey, targetAcceptedId))`
 returns every synonym of the target's accepted taxon. Synonyms whose target id is already
@@ -232,10 +256,15 @@ works for HIERARCHY-mode sectors with no new endpoint. The cancel path
 The combination of `deleteBySector` + sectorKey tagging means re-running the sync produces the same
 end state regardless of how many times it has run. Concretely:
 
-- imported above-genus ancestors are wiped and re-imported (with the same content; new ids).
+- imported ancestors and imported accepted taxa below genus are wiped and re-imported (with the same
+  content; new ids).
 - imported synonyms (phase 3) are wiped and re-imported.
 - project usages that were rewired or had their status flipped are *not* tagged with the sector;
-  the new run simply re-applies the same rewire / flip if the target still says so.
+  the new run simply re-applies the same rewire / flip if the target still says so. A usage demoted
+  to an imported accepted is a project synonym on the next run whose accepted was just deleted; it is
+  found again by its source identifier - which is why promoted name matches gain one - and retargeted
+  to the re-imported accepted.
+- a usage no longer matched on a later run keeps pointing at the deleted import, see Limitations.
 
 ## Limitations / Future work
 
@@ -243,8 +272,10 @@ The two items deferred from v1 — the name-match fallback and project-side dedu
 ancestors — were both implemented on 2026-06-26 (see
 [`2026-06-26-hierarchy-sync-name-match-fallback.md`](2026-06-26-hierarchy-sync-name-match-fallback.md)).
 Phase 1 runs a name-match sub-pass after the same `discoverMatches` scan: accepted project usages
-with no usable source identifier are matched against the source dataset and placed under their
-closest genus-or-higher anchor, flagged `Issue.MATCHING_HIGHERRANK`. No `TODO(hierarchy-sync)`
+with no usable source identifier are matched against the source dataset. Full matches are promoted to
+identifier matches (since 2026-09-11, see
+[`2026-09-11-hierarchy-sync-demote-to-missing-accepted.md`](2026-09-11-hierarchy-sync-demote-to-missing-accepted.md));
+the others are placed under their closest genus-or-higher anchor, flagged `Issue.MATCHING_HIGHERRANK`. No `TODO(hierarchy-sync)`
 markers remain in the source.
 
 ### What the name-match fallback refuses to do
@@ -270,13 +301,28 @@ genus *Platycladus* via the botanical genus synonym *Biota* D.Don ex Endl.
 
 A source identifier that no longer resolves in the source does **not** count as an identifier match.
 Sources delete and reissue ids, and trusting the mere presence of one shadowed the name fallback and
-left the usage unplaced on every subsequent run. Such usages are counted and logged at WARN.
+left the usage unplaced on every subsequent run. Such usages are counted and logged at WARN. A usage can
+therefore carry a stale id next to the current one, added by a later full name match; the first id that
+still resolves wins.
+
+These constraints guard every name match, including the full ones that get promoted to an identifier
+match. Only `EXACT` and `VARIANT` are promoted, and only when the matcher did not snap to the usage: a
+snap is its pick among several candidates, for example two source synonyms of the same accepted taxon.
+`CANONICAL`, `HIGHERRANK` and snapped matches stay placement only and flag the usage
+`MATCHING_HIGHERRANK`; see [the design record](2026-09-11-hierarchy-sync-demote-to-missing-accepted.md).
 
 What is still open, mirroring the javadoc on `HierarchySync`:
 
-- **Convergence for full matches.** Name-matched usages are placement-only and never gain the
-  source identifier, so a full EXACT match is re-matched by name on every run rather than
-  converging into the identifier path.
+- **Dangling references across `deleteOld`.** Imported usages get new ids on every run and nothing
+  relinks what points at them. Usages matched again are re-pointed, anything else - a usage the source
+  no longer has, a curator's edit under an imported taxon, a sector targeting one - keeps pointing at
+  a deleted row, and so does everything while a sync runs or after one failed between the delete and
+  phase 2. Stable ids and a repair step are planned separately.
+- **Wrong full name matches stick.** A promoted name match gains the source identifier, which
+  `deleteBySector` does not remove from untagged usages, so later runs follow that identifier.
+- **Snapped matches stay placement only.** When a name matches several source synonyms of the same
+  accepted taxon (e.g. *Gyraulus crista* and *Gyraulus (Armiger) crista*) the matcher snaps to one of
+  them and the usage is not demoted by name.
 - **Bad placements are not self-healing.** A rewire is not tagged with the sector, so a re-run does
   not undo one — `placeNameMatches` sees the parent already equals the target and re-affirms it. A
   wrong placement has to be corrected in the project by hand.


### PR DESCRIPTION
Fixes #1582

## Problem

The Archis project (316318) takes its higher classification from COL26.8 XR through hierarchy sector 5. Its names carry COL ids added on import, and for the two names of the issue those ids point at COL **synonyms** whose accepted taxon the project does not contain:

| project usage | identifier | that id in COL | accepted in COL |
|---|---|---|---|
| *Gyraulus crista* | `col:3HYBL` | *Gyraulus (Armiger) crista*, synonym | *Armiger crista* |
| *Hieracium pilosella* | `col:3LS95` | *Hieracium pilosella* L., synonym | *Pilosella officinarum* |

Phase 2 could only demote to an accepted taxon already in the project, so both stayed accepted. Phase 1 had also rewired the still accepted usage under the closest ancestor of the source accepted, which put *Gyraulus crista* into the genus *Armiger*. The unranked *Pilosella* in the issue comes from the text tree data and is not addressed here.

## Change (`HierarchySync`)

- **Import the missing accepted** (below genus) together with the ancestors, tagged with the sector, under the closest ancestor of its source chain the project holds, and demote the project usage to it. On a re-run the demoted synonym is found by its identifier and retargeted to the re-imported accepted.
- **No premature rewire**: an accepted usage matched to a source synonym is left for phase 2 and never reused as its own accepted by the ancestor dedup.
- **Full name matches** (unsnapped `EXACT`/`VARIANT`) are promoted to identifier matches: status, synonymy and authorship follow the source and the usage gains the source identifier. `CANONICAL`, `HIGHERRANK`, snapped and ambiguous matches stay placement only. All #1575 guards are unchanged.
- The first identifier that still resolves wins, as a usage may now carry a stale id next to the current one.
- **Promotions run before demotions**; unresolvable ones are logged at WARN and added as a sync warning with example names.

## Tests

`HierarchySyncIT`: 27 tests, 0 failures. New tests cover the identifier and name match (exact and variant) shapes of the issue, their re-runs, reuse of an existing project accepted, an infraspecific accepted whose species is missing, and a guard that an authorship conflict stays a higher rank placement. Changed expectations, deliberately:
- `nameMatchFullMatchPlacesUnderGenus`, `nameMatchRescuesStaleIdentifier`: a full match gains the identifier and is no longer flagged `MATCHING_HIGHERRANK`.
- `invertedSynonymyDoesNotCreateCycle`: now asserts the pair ends up as in the source (B accepted, A its synonym), not only that no cycle formed.

## Docs

`docs/HIERARCHY-SYNC.md` updated; design record `docs/2026-09-11-hierarchy-sync-demote-to-missing-accepted.md`.

## Not in this PR

Hierarchy re-syncs delete and re-import their rows under new ids without relinking what points at them, and prod does not enforce the partitioned `parent_id` FK. A follow-up PR adds stable ids for re-imported rows, a repair of dangling parents after every sync, and the same repair in `ProjectRelease`, which otherwise aborts in `IdProvider` on a missing parent.

After deploying, re-sync hierarchy sector 5 of project 316318 to fix the names of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNkG15eJStkCrMdDYrHaXA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hierarchy synchronization by recognizing exact and variant name matches when identifiers are unavailable or outdated.
  * Automatically imports missing accepted taxa below genus and demotes project synonyms to the appropriate accepted taxon.
  * Preserves correct parent placement for infraspecific taxa and handles synchronization order more reliably.
  * Reports unresolved promotions and demotions as synchronization warnings.

* **Bug Fixes**
  * Prevents incorrect synonym relationships and stale identifier matches during hierarchy updates.
  * Avoids demotions when authorship conflicts make a reliable match impossible.

* **Documentation**
  * Updated hierarchy synchronization guidance, limitations, and repeatability expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->