### PR TITLE
fix(hierarchy-sync): keep ids of re-imported usages and repair dangling parents

### DIFF
--- a/core/src/main/java/life/catalogue/assembly/HierarchySync.java
+++ b/core/src/main/java/life/catalogue/assembly/HierarchySync.java
@@ -12,6 +12,7 @@ import life.catalogue.api.model.SimpleNameClassified;
 import life.catalogue.api.model.Synonym;
 import life.catalogue.api.model.Taxon;
 import life.catalogue.api.model.VerbatimSource;
+import life.catalogue.api.model.VernacularName;
 import life.catalogue.api.vocab.DatasetOrigin;
 import life.catalogue.api.vocab.EntityType;
 import life.catalogue.api.vocab.ImportState;
@@ -26,6 +27,7 @@ import life.catalogue.dao.CopyUtil;
 import life.catalogue.dao.DatasetInfoCache;
 import life.catalogue.dao.SectorDao;
 import life.catalogue.dao.SectorImportDao;
+import life.catalogue.dao.TreeRepair;
 import life.catalogue.db.SectorProcessable;
 import life.catalogue.db.mapper.NameMapper;
 import life.catalogue.db.mapper.NameUsageMapper;
@@ -33,6 +35,7 @@ import life.catalogue.db.mapper.SectorMapper;
 import life.catalogue.db.mapper.SynonymMapper;
 import life.catalogue.db.mapper.TaxonMapper;
 import life.catalogue.db.mapper.VerbatimSourceMapper;
+import life.catalogue.db.mapper.VernacularNameMapper;
 import life.catalogue.es.indexing.NameUsageIndexService;
 import life.catalogue.event.EventBroker;
 import life.catalogue.matching.IdentifierScopeResolver;
@@ -182,6 +185,16 @@ public class HierarchySync extends SectorRunnable {
   private final Map<String, List<String>> acceptedChains = new HashMap<>();
   /** accepted project usages matched to a source synonym. Phase 2 demotes them, so phase 1 neither moves nor reuses them. */
   private final Set<String> pendingDemotes = new HashSet<>();
+  /**
+   * source id -> project id of the usages the previous run imported, read before they are deleted. A usage imported
+   * again for the same source id gets its old id back, so references to it stay valid. Each id is handed out once.
+   */
+  private final Map<String, String> previousIds = new HashMap<>();
+  /**
+   * source id of a previous import -> the vernacular names other sectors (merge sectors) attached to it. They have
+   * to go before the import can be deleted, and are attached again to whatever represents that source id afterwards.
+   */
+  private final Map<String, List<VernacularName>> foreignVernaculars = new HashMap<>();
 
   /** Lazily-filled cache for source dataset usages; constructed/closed around the four phases in {@link #doWork()}. */
   private UsageCache sourceCache;
@@ -253,13 +266,16 @@ public class HierarchySync extends SectorRunnable {
     // classification CTEs and per-match source row fetches on larger projects.
     final File cacheFile = new File(System.getProperty("java.io.tmpdir"),
       "HierarchySync-UC-" + sectorKey.getId() + "-" + UUID.randomUUID());
+    boolean deleted = false;
     try (UsageCache cache = UsageCache.mapDB(sourceDatasetKey, cacheFile);
          SqlSession loaderSession = factory.openSession(true)) {
       this.sourceCache = cache;
       this.sourceLoader = new CacheLoader.MybatisSession(loaderSession, sourceDatasetKey);
 
       setStep(ImportState.DELETING);
+      detachPreviousImports();
       deleteOld();
+      deleted = true;
       // from here on the project no longer holds what the last successful attempt measured,
       // so a failure must not leave sector.sync_attempt pointing at it - see pinFailedAttempt()
       markDataDestroyed();
@@ -289,6 +305,19 @@ public class HierarchySync extends SectorRunnable {
     } finally {
       this.sourceCache = null;
       this.sourceLoader = null;
+      // never mask the error of a failed sync with one of these
+      try {
+        reattachForeignVernaculars(!deleted);
+      } catch (RuntimeException e) {
+        LOG.error("Hierarchy sector {}: failed to attach the vernacular names of other sectors again", sectorKey, e);
+      }
+      if (deleted) {
+        try {
+          repairDanglingParents();
+        } catch (RuntimeException e) {
+          LOG.error("Hierarchy sector {}: failed to repair usages with a parent that no longer exists", sectorKey, e);
+        }
+      }
     }
   }
 
@@ -343,6 +372,7 @@ public class HierarchySync extends SectorRunnable {
 
     // Pass 3: insert ancestors top-down with project-side dedup; populates sourceToProject.
     insertAncestorsTopDown(projectKey, ancestorsToInsert, sourceScope);
+    reattachForeignVernaculars(false);
 
     // Pass 4: rewire id-matched accepted usages to their closest project ancestor.
     rewireProjectParents(projectKey, sourceChainForAccepted);
@@ -838,8 +868,9 @@ public class HierarchySync extends SectorRunnable {
             t.getName().setVerbatimSourceKey(v.getId());
           }
           // copy. No extension entities; reference linkage is dropped in this phase.
+          // the id the previous run gave the import of this source taxon, so nothing pointing at it dangles
           CopyUtil.copyUsage(batch, t, DSID.of(projectKey, projectParentId), user, Set.of(),
-            ref -> null, refId -> null);
+            CopyUtil.ID_GENERATOR, CopyUtil.ID_GENERATOR, sn -> reuseId(origSourceId), nidx -> null, ref -> null, refId -> null);
 
           // CopyUtil mutated t to its new project id - record mapping
           sourceToProject.put(origSourceId, t.getId());
@@ -1326,8 +1357,9 @@ public class HierarchySync extends SectorRunnable {
             syn.getName().setVerbatimSourceKey(v.getId());
           }
           // copy. parent = the project's accepted taxon. No extension entities; reference linkage dropped.
+          // The synonym keeps the id the previous run gave it.
           CopyUtil.copyUsage(batch, syn, DSID.of(projectKey, projectAcceptedId), user, Set.of(),
-            ref -> null, refId -> null);
+            CopyUtil.ID_GENERATOR, CopyUtil.ID_GENERATOR, sn -> reuseId(origSourceId), nidx -> null, ref -> null, refId -> null);
 
           if (sourceScope != null) {
             writeNum.addIdentifier(DSID.of(projectKey, syn.getId()), List.of(new Identifier(sourceScope, origSourceId)));
@@ -1449,6 +1481,120 @@ public class HierarchySync extends SectorRunnable {
     writeVsm.create(v);
     pn.setVerbatimSourceKey(v.getId());
     return DSID.of(projectKey, v.getId());
+  }
+
+  /**
+   * Reads what the previous run imported before {@link #deleteOld()} removes it: the project id of every import by its
+   * source id, so the import of the same source taxon gets it back, and the vernacular names other sectors attached to
+   * the imported taxa. Those are taken off right away - their foreign key is enforced and would fail the delete.
+   * Every import carries a verbatim source with its source id, so this does not depend on an identifier scope.
+   */
+  private void detachPreviousImports() {
+    final int projectKey = sectorKey.getDatasetKey();
+    final Map<Integer, String> sourceIdsByVSKey = new HashMap<>();
+    final Map<String, String> importedTaxa = new HashMap<>(); // project id -> source id
+    // autoCommit=false keeps the cursors alive, see discoverMatches
+    try (SqlSession session = factory.openSession(false)) {
+      try (Cursor<VerbatimSource> cursor = session.getMapper(VerbatimSourceMapper.class).processSector(sector)) {
+        for (VerbatimSource v : cursor) {
+          if (v.getSourceId() != null) {
+            sourceIdsByVSKey.put(v.getId(), v.getSourceId());
+          }
+        }
+      }
+      try (Cursor<NameUsageBase> cursor = session.getMapper(NameUsageMapper.class).processSector(sector)) {
+        for (NameUsageBase u : cursor) {
+          String sourceId = u.getVerbatimSourceKey() == null ? null : sourceIdsByVSKey.get(u.getVerbatimSourceKey());
+          if (sourceId != null) {
+            previousIds.putIfAbsent(sourceId, u.getId());
+            if (u.getStatus() != null && u.getStatus().isTaxon()) {
+              importedTaxa.put(u.getId(), sourceId);
+            }
+          }
+        }
+      }
+    } catch (java.io.IOException e) {
+      throw new RuntimeException("Failed to read the previous imports of hierarchy sector " + sectorKey, e);
+    }
+
+    int detached = 0;
+    try (SqlSession session = factory.openSession(true)) {
+      VernacularNameMapper vm = session.getMapper(VernacularNameMapper.class);
+      for (Map.Entry<String, String> e : importedTaxa.entrySet()) {
+        final DSID<String> key = DSID.of(projectKey, e.getKey());
+        List<VernacularName> vnames = vm.listByTaxon(key);
+        if (!vnames.isEmpty()) {
+          // this sector copies no extensions, so all of them came from another sector
+          foreignVernaculars.computeIfAbsent(e.getValue(), k -> new ArrayList<>()).addAll(vnames);
+          vm.deleteByTaxon(key);
+          detached += vnames.size();
+        }
+      }
+    }
+    LOG.info("Hierarchy sector {}: read {} previous imports and detached {} vernacular names other sectors attached to them",
+      sectorKey, previousIds.size(), detached);
+  }
+
+  /**
+   * Attaches the vernacular names taken off the previous imports to whatever represents their source taxon now: the
+   * re-import - under its old id - or an existing project usage it was deduplicated against. Names whose source taxon
+   * was not imported again are dropped with a warning; their merge sector brings them back on its next sync.
+   * Idempotent, every name is attached at most once.
+   *
+   * @param previousImportsExist true if the previous imports were never deleted, so the names go back where they were
+   */
+  private void reattachForeignVernaculars(boolean previousImportsExist) {
+    if (foreignVernaculars.isEmpty()) return;
+    int attached = 0;
+    int dropped = 0;
+    try (SqlSession session = factory.openSession(true)) {
+      VernacularNameMapper vm = session.getMapper(VernacularNameMapper.class);
+      var iter = foreignVernaculars.entrySet().iterator();
+      while (iter.hasNext()) {
+        var e = iter.next();
+        String projectId = previousImportsExist ? previousIds.get(e.getKey()) : sourceToProject.get(e.getKey());
+        if (projectId == null) {
+          dropped += e.getValue().size();
+        } else {
+          for (VernacularName vn : e.getValue()) {
+            vn.setId(null);
+            vm.create(vn, projectId);
+            attached++;
+          }
+        }
+        iter.remove();
+      }
+    }
+    if (dropped > 0) {
+      LOG.warn("Hierarchy sector {}: dropped {} vernacular names of other sectors whose taxon is no longer imported", sectorKey, dropped);
+      state.addWarning(String.format("%d vernacular names of other sectors were dropped, as their taxon is no longer imported", dropped));
+    }
+    LOG.info("Hierarchy sector {}: attached {} vernacular names of other sectors again", sectorKey, attached);
+  }
+
+  /**
+   * @return the id the previous run gave the import of this source taxon - handed out once - or a new one
+   */
+  private String reuseId(String sourceId) {
+    String id = previousIds.remove(sourceId);
+    return id != null ? id : CopyUtil.ID_GENERATOR.get();
+  }
+
+  /**
+   * Moves the usages of the project whose parent no longer exists to the root and flags them, see
+   * {@link TreeRepair#fixMissingParents}. Whatever pointed at an import whose source taxon is gone dangles otherwise -
+   * or at every import, when the sync failed after deleting them. Covers the whole project, so it also catches what
+   * other syncs left behind.
+   */
+  private void repairDanglingParents() {
+    try (SqlSession session = factory.openSession(false)) {
+      List<String> repaired = TreeRepair.fixMissingParents(session, sectorKey.getDatasetKey(), null, user);
+      session.commit();
+      if (!repaired.isEmpty()) {
+        state.addWarning(String.format("%d usages pointed at a parent that no longer exists and were moved to the root, e.g. %s",
+          repaired.size(), String.join(", ", repaired.subList(0, Math.min(5, repaired.size())))));
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/life/catalogue/release/ProjectRelease.java
+++ b/core/src/main/java/life/catalogue/release/ProjectRelease.java
@@ -258,6 +258,16 @@ public class ProjectRelease extends AbstractProjectCopy {
       prevReleaseKey = session.getMapper(DatasetMapper.class).previousRelease(newDatasetKey);
     }
 
+    // the id provider walks every classification and aborts on a parent that no longer exists,
+    // which a sector re-sync can leave behind in the project
+    try (SqlSession session = factory.openSession(false)) {
+      var repaired = TreeRepair.fixMissingParents(session, projectKey, null, user);
+      session.commit();
+      if (!repaired.isEmpty()) {
+        LOG.warn("Moved {} usages of project {} with a parent that no longer exists to the root", repaired.size(), projectKey);
+      }
+    }
+
     // map ids
     start = LocalDateTime.now();
     updateState(ImportState.MATCHING);

--- a/core/src/main/java/life/catalogue/release/XRelease.java
+++ b/core/src/main/java/life/catalogue/release/XRelease.java
@@ -431,24 +431,9 @@ public class XRelease extends ProjectRelease {
       }
 
       // look for non existing parents
-      var num = session.getMapper(NameUsageMapper.class);
-      var missing = num.listMissingParentIds(tmpProjectKey);
-      if (missing != null && !missing.isEmpty()) {
-        LOG.error("{} usages found with a non existing parentID", missing.size());
-        final String parent;
-        if (mergeCfg.hasIncertae()) {
-          parent = mergeCfg.incertae.getId();
-        } else {
-          parent = null;
-        }
-        final DSID<String> key = DSID.root(tmpProjectKey);
-        for (String id : missing) {
-          key.id(id);
-          num.updateParentId(key, parent, user);
-          adder.addIssue(id, Issue.PARENT_ID_INVALID);
-          session.commit();
-        }
-        LOG.warn("Resolved {} usages with a non existing parent in dataset {}", missing.size(),newDatasetKey);
+      var missing = TreeRepair.fixMissingParents(session, tmpProjectKey, mergeCfg.hasIncertae() ? mergeCfg.incertae.getId() : null, user);
+      if (!missing.isEmpty()) {
+        LOG.warn("Resolved {} usages with a non existing parent in dataset {}", missing.size(), newDatasetKey);
       }
       session.commit();
     }

--- a/core/src/test/java/life/catalogue/assembly/HierarchySyncIT.java
+++ b/core/src/test/java/life/catalogue/assembly/HierarchySyncIT.java
@@ -18,8 +18,8 @@ import life.catalogue.junit.SqlSessionFactoryRule;
 import life.catalogue.junit.TestDataRule;
 import life.catalogue.junit.TreeRepoRule;
 import life.catalogue.matching.IdentifierScopeResolver;
+import life.catalogue.matching.UsageMatcher;
 import life.catalogue.matching.UsageMatcherFactory;
-import life.catalogue.matching.nidx.NameIndex;
 
 import org.gbif.nameparser.api.Authorship;
 import org.gbif.nameparser.api.NameType;
@@ -28,6 +28,7 @@ import org.gbif.nameparser.api.Rank;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.BiFunction;
 
 import org.apache.ibatis.session.SqlSession;
 import org.junit.AfterClass;
@@ -1011,7 +1012,139 @@ public class HierarchySyncIT {
     matchingRule.rematch(PROJECT_KEY);
   }
 
+  // ---------- references to imported usages across re-syncs ----------
+
+  /**
+   * A re-sync deletes what the sector imported and imports it again. It has to come back under the same ids,
+   * or everything pointing at the imported usages - children, synonyms, sector targets - dangles.
+   */
+  @Test
+  public void resyncKeepsIdsOfImportedUsages() throws Exception {
+    runHierarchySync();
+    String felidae = getByName(PROJECT_KEY, Rank.FAMILY, "Felidae").getId();
+    String silvestris = getByName(PROJECT_KEY, Rank.SPECIES, "Felis silvestris").getId();
+
+    runHierarchySync();
+
+    assertEquals("an imported ancestor must keep its id", felidae, getByName(PROJECT_KEY, Rank.FAMILY, "Felidae").getId());
+    assertEquals("a copied synonym must keep its id", silvestris, getByName(PROJECT_KEY, Rank.SPECIES, "Felis silvestris").getId());
+  }
+
+  /**
+   * A curator places a taxon under an imported ancestor. The next sync must not leave it pointing at a deleted row.
+   */
+  @Test
+  public void usageUnderImportedTaxonSurvivesResync() throws Exception {
+    runHierarchySync();
+    String felidae = getByName(PROJECT_KEY, Rank.FAMILY, "Felidae").getId();
+    insertTaxon(PROJECT_KEY, P_Custom, felidae, Rank.GENUS, "Customia");
+
+    runHierarchySync();
+
+    NameUsageBase custom = getByID(PROJECT_KEY, P_Custom);
+    assertEquals(felidae, custom.getParentId());
+    assertNotNull("the parent must still exist", getByID(PROJECT_KEY, custom.getParentId()));
+    assertEquals(0, verbatimIssueCount(PROJECT_KEY, P_Custom, Issue.PARENT_ID_INVALID));
+  }
+
+  /**
+   * A merge sector adds vernacular names to usages another sector owns - the imported ancestors included.
+   * They carry the merge sector's key, so the hierarchy sync neither deletes nor copies them, and they must survive.
+   */
+  @Test
+  public void foreignVernacularOnImportedTaxonSurvivesResync() throws Exception {
+    runHierarchySync();
+    String felidae = getByName(PROJECT_KEY, Rank.FAMILY, "Felidae").getId();
+    Sector merge = createMergeSector();
+    try (SqlSession s = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {
+      VernacularName vn = new VernacularName();
+      vn.setDatasetKey(PROJECT_KEY);
+      vn.setSectorKey(merge.getId());
+      vn.setName("Katzen");
+      vn.setLanguage("deu");
+      vn.applyUser(USER);
+      s.getMapper(VernacularNameMapper.class).create(vn, felidae);
+    }
+
+    runHierarchySync();
+
+    try (SqlSession s = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {
+      var vnames = s.getMapper(VernacularNameMapper.class).listByTaxon(DSID.of(PROJECT_KEY, felidae));
+      assertEquals("the merge sector's vernacular must still be attached to Felidae", 1, vnames.size());
+      assertEquals("Katzen", vnames.get(0).getName());
+    }
+  }
+
+  /**
+   * The source dropped a taxon the project still refers to. Whatever is left pointing at the deleted import loses its
+   * parent and is flagged, instead of dangling: a missing parent aborts releases and a synonym without accepted aborts
+   * the search index.
+   */
+  @Test
+  public void referencesToDroppedImportsAreRepaired() throws Exception {
+    runHierarchySync();
+    String felidae = getByName(PROJECT_KEY, Rank.FAMILY, "Felidae").getId();
+    insertTaxon(PROJECT_KEY, P_Custom, felidae, Rank.GENUS, "Customia");
+    insertSynonym(PROJECT_KEY, P_Custom_syn, felidae, Rank.FAMILY, "Customiidae");
+    // the source dissolves Felidae
+    setParent(targetKey, T_Felis, T_Animalia);
+    deleteUsage(targetKey, T_Felidae);
+
+    HierarchySync sync = runHierarchySync();
+
+    NameUsageBase custom = getByID(PROJECT_KEY, P_Custom);
+    assertNull("a taxon under the dropped import must lose its parent", custom.getParentId());
+    assertHasVerbatimIssue(PROJECT_KEY, P_Custom, Issue.PARENT_ID_INVALID);
+    NameUsageBase syn = getByID(PROJECT_KEY, P_Custom_syn);
+    assertNull("a synonym of the dropped import must lose its accepted", syn.getParentId());
+    assertHasVerbatimIssue(PROJECT_KEY, P_Custom_syn, Issue.ACCEPTED_ID_INVALID);
+    assertTrue("the sync should warn about the repair: " + sync.getState().getWarnings(),
+      sync.getState().getWarnings().stream().anyMatch(w -> w.startsWith("2 usages pointed at a parent that no longer exists")));
+  }
+
+  /**
+   * A sync that fails after deleting its imports must still repair what points at them.
+   */
+  @Test
+  public void failedSyncStillRepairsDanglingParents() throws Exception {
+    runHierarchySync();
+    String felidae = getByName(PROJECT_KEY, Rank.FAMILY, "Felidae").getId();
+    insertTaxon(PROJECT_KEY, P_Custom, felidae, Rank.GENUS, "Customia");
+
+    // the source matcher is first needed right after the old imports are gone
+    HierarchySync sync = newHierarchySync((dk, session) -> {
+      throw new IllegalStateException("source matcher unavailable");
+    });
+    sync.run();
+    assertEquals(JobStatus.FAILED, sync.getStatus());
+
+    NameUsageBase custom = getByID(PROJECT_KEY, P_Custom);
+    assertNull(custom.getParentId());
+    assertHasVerbatimIssue(PROJECT_KEY, P_Custom, Issue.PARENT_ID_INVALID);
+  }
+
+  static final String P_Custom = "p_custom";
+  static final String P_Custom_syn = "p_custom_syn";
+
   // ---------- helpers ----------
+
+  private static Sector createMergeSector() {
+    try (SqlSession s = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {
+      Sector sector = new Sector();
+      sector.setMode(Sector.Mode.MERGE);
+      sector.setDatasetKey(PROJECT_KEY);
+      sector.setSubjectDatasetKey(targetKey);
+      sector.applyUser(USER);
+      s.getMapper(SectorMapper.class).create(sector);
+      return sector;
+    }
+  }
+
+  private static void deleteUsage(int datasetKey, String id) {
+    try (SqlSession s = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {
+      s.getMapper(NameUsageMapper.class).delete(DSID.of(datasetKey, id));
+    }
+  }
 
   private static void insertSynonymWithAuthorship(int datasetKey, String id, String acceptedId, Rank rank, String scientificName,
                                                   Authorship combinationAuthorship) {
@@ -1047,34 +1180,38 @@ public class HierarchySyncIT {
     }
   }
 
-  private void runHierarchySync() throws Exception {
+  private HierarchySync runHierarchySync() throws Exception {
+    HierarchySync sync = newHierarchySync(null);
+    sync.run();
+    if (sync.getStatus() != JobStatus.FINISHED) {
+      throw new AssertionError("HierarchySync did not finish cleanly: status=" + sync.getStatus() + " error=" + sync.getState().getError());
+    }
+    return sync;
+  }
+
+  /**
+   * @param sourceMatcherProvider replaces the postgres matcher against the source dataset if given
+   */
+  private HierarchySync newHierarchySync(BiFunction<Integer, SqlSession, UsageMatcher> sourceMatcherProvider) {
     SectorDao sdao = new SectorDao(SqlSessionFactoryRule.getSqlSessionFactory(), NameUsageIndexService.passThru(), null, null);
     SectorImportDao siDao = new SectorImportDao(SqlSessionFactoryRule.getSqlSessionFactory(), TreeRepoRule.getRepo());
     EventBroker bus = TestUtils.mockedBroker();
-    NameIndex ni = NameMatchingRule.getIndex();
-    UsageMatcherFactory matcherFactory = new UsageMatcherFactory(new MatchingConfig(), ni, SqlSessionFactoryRule.getSqlSessionFactory(), null);
-    try {
-      HierarchySync sync = new HierarchySync(
-        hierarchySector,
-        SqlSessionFactoryRule.getSqlSessionFactory(),
-        session -> matcherFactory.postgres(PROJECT_KEY, session),
-        (dk, session) -> matcherFactory.postgres(dk, session),
-        LatestDatasetKeyCache.passThru(),
-        bus,
-        NameUsageIndexService.passThru(),
-        sdao,
-        siDao,
-        null,
-        scopeResolver,
-        USER
-      );
-      sync.run();
-      if (sync.getStatus() != JobStatus.FINISHED) {
-        throw new AssertionError("HierarchySync did not finish cleanly: status=" + sync.getStatus() + " error=" + sync.getState().getError());
-      }
-    } finally {
-      matcherFactory.close();
-    }
+    // postgres matchers read live data and hold no resources beyond the session they are given
+    UsageMatcherFactory matcherFactory = new UsageMatcherFactory(new MatchingConfig(), NameMatchingRule.getIndex(), SqlSessionFactoryRule.getSqlSessionFactory(), null);
+    return new HierarchySync(
+      hierarchySector,
+      SqlSessionFactoryRule.getSqlSessionFactory(),
+      session -> matcherFactory.postgres(PROJECT_KEY, session),
+      sourceMatcherProvider != null ? sourceMatcherProvider : (dk, session) -> matcherFactory.postgres(dk, session),
+      LatestDatasetKeyCache.passThru(),
+      bus,
+      NameUsageIndexService.passThru(),
+      sdao,
+      siDao,
+      null,
+      scopeResolver,
+      USER
+    );
   }
 
   private static int createExternalDataset(String title) {

--- a/core/src/test/java/life/catalogue/release/ProjectReleaseIT.java
+++ b/core/src/test/java/life/catalogue/release/ProjectReleaseIT.java
@@ -255,6 +255,38 @@ public class ProjectReleaseIT extends ProjectBaseIT {
     }
   }
 
+  /**
+   * A project usage whose parent no longer exists - what a hierarchy sector re-sync can leave behind - used to abort
+   * the release in the id provider. It is repaired in the project and flagged instead.
+   */
+  @Test
+  public void releaseRepairsMissingParents() throws Exception {
+    try (SqlSession session = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {
+      // 13 is the parent of the accepted 15 and 16 and of the synonym 14. Its vernacular name is enforced by a
+      // foreign key, the parent_id self reference is not.
+      session.getConnection().createStatement().execute("DELETE FROM vernacular_name WHERE dataset_key=" + projectKey + " AND taxon_id='13'");
+      var num = session.getMapper(NameUsageMapper.class);
+      num.delete(DSID.of(projectKey, "13"));
+      assertEquals(List.of("14", "15", "16"), num.listMissingParentIds(projectKey).stream().sorted().toList());
+    }
+
+    ProjectRelease release = buildRelease();
+    release.run();
+    assertEquals("release failed: " + release.getError(), JobStatus.FINISHED, release.getStatus());
+
+    try (SqlSession session = SqlSessionFactoryRule.getSqlSessionFactory().openSession(true)) {
+      var num = session.getMapper(NameUsageMapper.class);
+      assertTrue("the project must be repaired", num.listMissingParentIds(projectKey).isEmpty());
+      assertNull(num.get(DSID.of(projectKey, "15")).getParentId());
+      assertNull(num.get(DSID.of(projectKey, "14")).getParentId());
+      var vsm = session.getMapper(VerbatimSourceMapper.class);
+      assertTrue(vsm.getIssues(DSID.of(projectKey, vsm.getVSKeyByUsage(DSID.of(projectKey, "15"))))
+                    .getIssues().contains(life.catalogue.api.vocab.Issue.PARENT_ID_INVALID));
+      assertTrue(vsm.getIssues(DSID.of(projectKey, vsm.getVSKeyByUsage(DSID.of(projectKey, "14"))))
+                    .getIssues().contains(life.catalogue.api.vocab.Issue.ACCEPTED_ID_INVALID));
+    }
+  }
+
   @Test
   public void duplicationSubmitsNoRetentionJob() throws Exception {
     var jobExecutor = mock(JobExecutor.class);

--- a/dao/src/main/java/life/catalogue/dao/TreeRepair.java
+++ b/dao/src/main/java/life/catalogue/dao/TreeRepair.java
@@ -1,0 +1,58 @@
+package life.catalogue.dao;
+
+import life.catalogue.api.model.DSID;
+import life.catalogue.api.model.SimpleNameVerbatim;
+import life.catalogue.api.vocab.Issue;
+import life.catalogue.db.mapper.NameUsageMapper;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.apache.ibatis.session.SqlSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Repairs a broken classification of a project or release in place.
+ */
+public class TreeRepair {
+  private static final Logger LOG = LoggerFactory.getLogger(TreeRepair.class);
+
+  private TreeRepair() {
+  }
+
+  /**
+   * Points every usage whose parent does not exist at the fallback parent instead and flags it:
+   * {@link Issue#PARENT_ID_INVALID} for an accepted usage, {@link Issue#ACCEPTED_ID_INVALID} for a synonym, whose
+   * parent is its accepted name.
+   *
+   * Postgres does not enforce the partitioned parent_id self reference, so deleting a parent - a sector re-sync
+   * deletes all it imported - silently leaves its children behind. Whatever walks the classification cannot deal with
+   * them: releases, the search index and the usage matchers.
+   *
+   * The caller commits the session.
+   *
+   * @param fallbackParentId the new parent of the repaired usages, null to make them roots
+   * @return ids of the repaired usages
+   */
+  public static List<String> fixMissingParents(SqlSession session, int datasetKey, @Nullable String fallbackParentId, int user) {
+    NameUsageMapper num = session.getMapper(NameUsageMapper.class);
+    List<String> missing = num.listMissingParentIds(datasetKey);
+    if (missing == null || missing.isEmpty()) {
+      return List.of();
+    }
+    LOG.warn("{} usages of dataset {} point at a parent that does not exist. Move them to {}", missing.size(), datasetKey,
+      fallbackParentId == null ? "the root" : fallbackParentId);
+    final IssueAdder adder = new IssueAdder(datasetKey, session);
+    final DSID<String> key = DSID.root(datasetKey);
+    for (String id : missing) {
+      key.id(id);
+      SimpleNameVerbatim u = num.getSimpleVerbatim(key);
+      num.updateParentId(key, fallbackParentId, user);
+      boolean synonym = u.getStatus() != null && u.getStatus().isSynonym();
+      adder.addIssue(u.getVerbatimSourceKey(), id, synonym ? Issue.ACCEPTED_ID_INVALID : Issue.PARENT_ID_INVALID);
+    }
+    return missing;
+  }
+}

--- a/dao/src/test/java/life/catalogue/dao/TreeRepairTest.java
+++ b/dao/src/test/java/life/catalogue/dao/TreeRepairTest.java
@@ -1,0 +1,86 @@
+package life.catalogue.dao;
+
+import life.catalogue.api.model.DSID;
+import life.catalogue.api.model.VerbatimSource;
+import life.catalogue.api.vocab.Issue;
+import life.catalogue.api.vocab.TaxonomicStatus;
+import life.catalogue.api.vocab.Users;
+import life.catalogue.db.mapper.NameUsageMapper;
+import life.catalogue.db.mapper.VerbatimSourceMapper;
+import life.catalogue.junit.TestDataRule;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.ibatis.session.SqlSession;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TreeRepairTest extends DaoTestBase {
+  static final int KEY = TestDataRule.DRAFT.key;
+
+  public TreeRepairTest() {
+    super(new TestDataRule(TestDataRule.DRAFT));
+  }
+
+  /**
+   * p2 has the accepted children c1 and c2, p3 has c3 which we turn into a synonym. Deleting both parents leaves
+   * all three pointing at rows that no longer exist.
+   */
+  @Before
+  public void dropParents() {
+    try (SqlSession s = factory().openSession(true)) {
+      NameUsageMapper num = s.getMapper(NameUsageMapper.class);
+      num.updateStatus(DSID.of(KEY, "c3"), TaxonomicStatus.SYNONYM, Users.TESTER);
+      num.delete(DSID.of(KEY, "p2"));
+      num.delete(DSID.of(KEY, "p3"));
+    }
+  }
+
+  @Test
+  public void fixMissingParents() {
+    List<String> fixed;
+    try (SqlSession s = factory().openSession(false)) {
+      fixed = TreeRepair.fixMissingParents(s, KEY, null, Users.TESTER);
+      s.commit();
+    }
+    assertEquals(Set.of("c1", "c2", "c3"), Set.copyOf(fixed));
+
+    try (SqlSession s = factory().openSession(true)) {
+      NameUsageMapper num = s.getMapper(NameUsageMapper.class);
+      assertNull(num.get(DSID.of(KEY, "c1")).getParentId());
+      assertNull(num.get(DSID.of(KEY, "c3")).getParentId());
+      assertTrue("the status is kept", num.get(DSID.of(KEY, "c3")).getStatus().isSynonym());
+      assertEquals(Set.of(Issue.PARENT_ID_INVALID), issues(s, "c1"));
+      assertEquals(Set.of(Issue.ACCEPTED_ID_INVALID), issues(s, "c3"));
+      // untouched
+      assertEquals("k1", num.get(DSID.of(KEY, "p1")).getParentId());
+      assertEquals(Set.of(), issues(s, "p1"));
+
+      assertTrue("nothing is left to repair", TreeRepair.fixMissingParents(s, KEY, null, Users.TESTER).isEmpty());
+    }
+  }
+
+  @Test
+  public void fixMissingParentsWithFallback() {
+    try (SqlSession s = factory().openSession(false)) {
+      TreeRepair.fixMissingParents(s, KEY, "b", Users.TESTER);
+      s.commit();
+    }
+    try (SqlSession s = factory().openSession(true)) {
+      NameUsageMapper num = s.getMapper(NameUsageMapper.class);
+      assertEquals("b", num.get(DSID.of(KEY, "c1")).getParentId());
+      assertEquals("b", num.get(DSID.of(KEY, "c3")).getParentId());
+    }
+  }
+
+  private static Set<Issue> issues(SqlSession s, String usageId) {
+    VerbatimSourceMapper vsm = s.getMapper(VerbatimSourceMapper.class);
+    Integer vsKey = vsm.getVSKeyByUsage(DSID.of(KEY, usageId));
+    if (vsKey == null) return Set.of();
+    VerbatimSource v = vsm.getIssues(DSID.of(KEY, vsKey));
+    return v == null || v.getIssues() == null ? Set.of() : Set.copyOf(v.getIssues());
+  }
+}

--- a/docs/2026-09-11-hierarchy-sync-stable-ids.md
+++ b/docs/2026-09-11-hierarchy-sync-stable-ids.md
@@ -1,0 +1,88 @@
+# Hierarchy sync: stable ids and repair of dangling parents
+
+Date: 2026-09-11
+Status: implemented on branch `feat/hierarchy-stable-ids`, stacked on
+[#1583](https://github.com/CatalogueOfLife/backend/pull/1583), not yet released
+Follows: [2026-09-11-hierarchy-sync-demote-to-missing-accepted.md](2026-09-11-hierarchy-sync-demote-to-missing-accepted.md)
+
+## Problem
+
+A hierarchy sync starts by deleting everything its sector imported (`deleteOld`, a plain `DELETE` per
+`SectorProcessable` mapper) and then imports it again, until now under new random ids. Untagged rows
+keep pointing at the deleted ones:
+
+- accepted usages rewired under an imported ancestor, and name matches placed under one,
+- usages demoted to a synonym of an imported accepted (since the fix for backend#1582),
+- a curator's edits under an imported taxon, attach sector targets, estimates,
+- vernacular names and other extensions a merge sector adds to imported taxa.
+
+Usages matched again on the next run are re-pointed; everything else dangles. The partitioned
+`parent_id` self reference is not enforced in prod (PostgreSQL before 17.5 missed the catalog entries
+for partitions created after the constraint), so nothing stops it. What a dangling parent does:
+
+- `ProjectRelease` aborts: `IdProvider` walks every classification through `UsageMatcherStore.analyze`,
+  which throws on a missing parent. Only `XRelease.flagLoops` repaired missing parents.
+- Indexing a dataset aborts on a synonym without its accepted (`NameUsageProcessor`).
+- Tree views, taxon metrics and subtree exports walk from the roots and silently lose the subtree.
+
+## Goal
+
+- Re-import a taxon the source still has under the project id it had before, so references stay valid
+  after a successful run.
+- After every sync - failed ones included - set the parent of usages pointing at a missing row to null
+  and flag them `PARENT_ID_INVALID` (accepted) or `ACCEPTED_ID_INVALID` (synonym), with a sync warning.
+- Run the same repair on the project before `ProjectRelease` maps ids, and reuse it in `XRelease`.
+
+## Non-goals
+
+- The window during a sync, between `deleteOld` and the re-import, stays. Every sector sync has it, and
+  a single transaction around it is ruled out by the 15 minute idle-in-transaction limit in prod.
+- Rematching attach sector targets and estimates whose taxon the source dropped. Stable ids keep them
+  valid as long as the taxon exists; broken targets are already flagged and have rematch endpoints, and
+  `HierarchySync` has no estimate dao wired.
+- Recreating the parent FK so postgres enforces it.
+
+## Design
+
+- **Stable ids.** Before `deleteOld` the sync streams its sector's verbatim sources and usages and keeps
+  `source id -> project id`. Every imported usage carries a verbatim source with its source id, so this does
+  not depend on an identifier scope being configured. `insertAncestorsTopDown` and `copySynonymies` pass an
+  id supplier to `CopyUtil.copyUsage` that hands out each previous id at most once and falls back to a new
+  random one. COL ids are stable across releases, so this survives a newer source release.
+- **Repair.** `TreeRepair.fixMissingParents` in the dao module lists `NameUsageMapper.listMissingParentIds`,
+  points each at the fallback parent (null for projects) and flags it through `IssueAdder`. `HierarchySync`
+  runs it from the `finally` of `doWork` once the old imports are deleted; a failure of the repair is logged
+  and never masks the sync's own error.
+- **Releases.** `ProjectRelease.prepWork` runs the repair on the project before building the `IdProvider`,
+  next to the existing orphan removal. `XRelease.flagLoops` calls it with the incertae sedis taxon.
+
+## Rejected alternatives
+
+- **Relink foreign children around the delete** like `SectorSync.relinkForeignChildren`. There is no valid
+  temporary parent for a synonym, and every other kind of reference needs its own rematch.
+- **Diff instead of delete and re-insert.** Would avoid the window too, but rewrites the repeatability contract
+  every sector mode shares.
+- **Only flag, keep the dangling parent.** Releases and indexing would still fail on it.
+- **Fail the sync.** The half-synced sector guard would then block releases until a curator fixes it by hand.
+
+## Outcome
+
+- Two assumptions were checked with failing tests before any code changed:
+  - `ProjectRelease` really aborts on a missing parent: `NotFoundException: NameUsage 3:13 does not exist` from the
+    id provider (`ProjectReleaseIT.releaseRepairsMissingParents`).
+  - A vernacular name a merge sector attached to an imported taxon **fails the next hierarchy sync** outright:
+    `vernacular_name.taxon_id` is enforced, unlike the `parent_id` self reference
+    (`HierarchySyncIT.foreignVernacularOnImportedTaxonSurvivesResync`). So the sync now takes those names off its
+    imports before deleting them and attaches them again after phase 1 - to the re-import, or to the project usage
+    it was deduplicated against. Names of taxa no longer imported are dropped with a sync warning; if a sync fails
+    midway, names that could not be attached are lost until their merge sector syncs again.
+  - `SectorSync.deleteOld` deletes the same way, so an attach or union sector with merge sector vernaculars on its
+    usages presumably fails likewise. Not addressed here.
+- Merge sectors only ever add vernacular names to usages they do not own (`TreeMergeHandler`), so no other
+  extension type needs the same treatment.
+- `XRelease.flagLoops` now repairs through `TreeRepair`: a synonym whose accepted is missing is flagged
+  `ACCEPTED_ID_INVALID` instead of `PARENT_ID_INVALID`.
+- Tests: `TreeRepairTest` (dao), `HierarchySyncIT` (ids kept across re-syncs, a curator's usage under an import,
+  a merge sector vernacular, repair after a dropped source taxon and after a failed sync), `ProjectReleaseIT`; the
+  existing `XReleaseIT` and `XReleaseBasicIT` pass unchanged.
+- Deferred as stated in the non-goals: rematching attach sector targets and estimates of dropped taxa.

--- a/docs/HIERARCHY-SYNC.md
+++ b/docs/HIERARCHY-SYNC.md
@@ -256,15 +256,27 @@ works for HIERARCHY-mode sectors with no new endpoint. The cancel path
 The combination of `deleteBySector` + sectorKey tagging means re-running the sync produces the same
 end state regardless of how many times it has run. Concretely:
 
-- imported ancestors and imported accepted taxa below genus are wiped and re-imported (with the same
-  content; new ids).
-- imported synonyms (phase 3) are wiped and re-imported.
+- imported ancestors, imported accepted taxa below genus and copied synonyms are wiped and re-imported
+  with the same content **and the same ids**. Before `deleteOld` the sync reads its verbatim sources and
+  keeps `source id -> project id`; the copy hands each previous id out again (at most once) for the same
+  source id, and a new random one otherwise. Everything pointing at an import - children, demoted
+  synonyms, a curator's edits, sector targets, estimates - is valid again once the run is done.
+- vernacular names a merge sector attached to an import carry the merge sector's key, and their foreign
+  key to `name_usage` *is* enforced, so they would make `deleteOld` fail. The sync takes them off its
+  imports before deleting them and attaches them again to whatever represents the same source id after
+  phase 1 - the re-import or an existing project usage it deduplicated against. Names whose source taxon
+  is gone are dropped with a warning; the merge sector brings them back on its next sync.
 - project usages that were rewired or had their status flipped are *not* tagged with the sector;
   the new run simply re-applies the same rewire / flip if the target still says so. A usage demoted
-  to an imported accepted is a project synonym on the next run whose accepted was just deleted; it is
-  found again by its source identifier - which is why promoted name matches gain one - and retargeted
-  to the re-imported accepted.
-- a usage no longer matched on a later run keeps pointing at the deleted import, see Limitations.
+  to an imported accepted is a project synonym on the next run; it is found again by its source
+  identifier - which is why promoted name matches gain one - and stays attached to the re-imported
+  accepted.
+- when the source dropped a taxon, whatever still points at its former import is repaired after the
+  sync, failed syncs included: `TreeRepair.fixMissingParents` sets the parent to null and flags the usage
+  `PARENT_ID_INVALID`, or `ACCEPTED_ID_INVALID` for a synonym, and the sync reports a warning with the count.
+  `ProjectRelease` runs the same repair on the project before it maps ids, `XRelease` with its incertae
+  sedis taxon as the new parent. See
+  [`2026-09-11-hierarchy-sync-stable-ids.md`](2026-09-11-hierarchy-sync-stable-ids.md).
 
 ## Limitations / Future work
 
@@ -313,11 +325,11 @@ snap is its pick among several candidates, for example two source synonyms of th
 
 What is still open, mirroring the javadoc on `HierarchySync`:
 
-- **Dangling references across `deleteOld`.** Imported usages get new ids on every run and nothing
-  relinks what points at them. Usages matched again are re-pointed, anything else - a usage the source
-  no longer has, a curator's edit under an imported taxon, a sector targeting one - keeps pointing at
-  a deleted row, and so does everything while a sync runs or after one failed between the delete and
-  phase 2. Stable ids and a repair step are planned separately.
+- **The window during a sync.** Between `deleteOld` and the re-import the imported rows are gone, so
+  the project serves dangling references for the minutes a sync runs, like with every other sector sync.
+- **Dropped source taxa lose more than their children's parent.** The repair only covers `parent_id`.
+  An attach sector targeting a taxon the source dropped is left with a broken target and estimates with
+  a broken reference - both are flagged as such and can be rematched.
 - **Wrong full name matches stick.** A promoted name match gains the source identifier, which
   `deleteBySector` does not remove from untagged usages, so later runs follow that identifier.
 - **Snapped matches stay placement only.** When a name matches several source synonyms of the same


### PR DESCRIPTION
Stacked on #1583 - review and merge that first, then rebase this onto master.

## Problem

A hierarchy sync deletes everything it imported and imports it again - until now under new random ids - without relinking what points at those rows: accepted usages rewired under an imported ancestor, synonyms demoted to an imported accepted (#1583), a curator's edits under an imported taxon, sector targets. The partitioned `parent_id` self reference is not enforced in postgres before 17.5, so nothing stops that, and a dangling parent then:

- **aborts a project release** in the id provider (`NotFoundException: NameUsage 3:13 does not exist`, reproduced in `ProjectReleaseIT`),
- aborts indexing on a synonym without its accepted (`NameUsageProcessor`),
- silently drops the subtree from tree views, metrics and subtree exports.

While testing this, a second, worse failure turned up: a **vernacular name a merge sector attached to an imported taxon makes the next hierarchy sync fail** in `deleteOld`, because `vernacular_name.taxon_id` *is* enforced.

## Change

- **Stable ids**: before `deleteOld` the sync reads `source id -> project id` of its previous imports (from their verbatim sources) and hands the same id out again when the same source taxon is imported - ancestors, imported accepted taxa and copied synonyms.
- **Foreign vernaculars**: taken off the imports before the delete and attached again after phase 1 to whatever represents the source taxon (the re-import or a deduplicated project usage). Names of taxa no longer imported are dropped with a sync warning.
- **Repair**: new `TreeRepair.fixMissingParents` moves usages whose parent no longer exists to a fallback parent (root for projects) and flags them `PARENT_ID_INVALID`, or `ACCEPTED_ID_INVALID` for synonyms. The hierarchy sync runs it after every sync, failed ones included, and reports a warning.
- **Releases**: `ProjectRelease` runs the repair on the project before mapping ids; `XRelease.flagLoops` uses the same helper with its incertae sedis taxon (synonyms are now flagged `ACCEPTED_ID_INVALID` there).

## Tests

- `TreeRepairTest` (dao): 2 new.
- `HierarchySyncIT`: 32 pass, 5 new - ids kept across re-syncs, a curator's usage under an import, a merge sector vernacular on an import, repair after the source drops a taxon, repair after a failed sync.
- `ProjectReleaseIT`: 6 pass, 1 new - a release over a project with a missing parent.
- `XReleaseIT` (9) and `XReleaseBasicIT` (1) pass unchanged.

All new tests failed before the change for the expected reason.

## Not in this PR

- Attach sector targets and estimates pointing at a taxon the source dropped are still left broken; both are flagged as such and can be rematched.
- `SectorSync.deleteOld` deletes the same way and very likely fails the same way for attach/merge sectors with other sectors' vernaculars on their usages - checked separately.
- The window during a sync, between the delete and the re-import.

Design record: `docs/2026-09-11-hierarchy-sync-stable-ids.md`; `docs/HIERARCHY-SYNC.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNkG15eJStkCrMdDYrHaXA
